### PR TITLE
Support for multiple data endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+data/
+supporting material/
+secrets.h
+*.sublime-project
+*.sublime-workspace

--- a/Feather_AQI_Monitor_SEN54.ino
+++ b/Feather_AQI_Monitor_SEN54.ino
@@ -1,421 +1,365 @@
 /*
- * Air Quality Monitor built using an Adafruit Feather Huzzah with a Sensirion SEN54 sensor.
- * Uses Sensirion's Arduino library for the SEN5x series. 
- * 
- * Reports observations over Wifi via the Feather Huzzah.  Data is posted to Dweet.io and
- * ThingSpeak, and stored via an InfluxDB service.  Because the data gets 
- * reported to the web there's no display, though useful information is output via the serial
- * monitor to streamline development.
- *
- * The SEN54 reports particulate mass concentrations (microgram per cubic meter) for 1, 2.5,
- * 4, and 10 micron particulates as well as VOC plus temperature and humidity.  Communication is
- * via I2C.
- * 
- * Note that Sensirion requires the following declaration:
- */
- /*
- * Copyright (c) 2021, Sensirion AG
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * * Redistributions of source code must retain the above copyright notice, this
- *   list of conditions and the following disclaimer.
- *
- * * Redistributions in binary form must reproduce the above copyright notice,
- *   this list of conditions and the following disclaimer in the documentation
- *   and/or other materials provided with the distribution.
- *
- * * Neither the name of Sensirion AG nor the names of its
- *   contributors may be used to endorse or promote products derived from
- *   this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+  Project Name:   PM2.5 monitor
+  Description:    Regularly sample and log PM 2.5 levels
 
-#include <Arduino.h>
-#include <SensirionI2CSen5x.h>
-#include <Wire.h>  
-#include <ESP8266WiFi.h>
+  See README.md for target information and revision history
+*/
+
+// SparkFun SEN5X
+//#include <SensirionI2CSen5x.h>
+//#include <Wire.h>
+
+// Adafruit PMSA003I
+#include "Adafruit_PM25AQI.h"
+
+#include "config.h"
 #include "secrets.h"
+
+#ifdef WiFi
+  // ESP32 WiFi
+  #include <WiFi.h>
+
+  // ESP8266 WiFi
+  #include <ESP8266WiFi.h>
+
+  // Use WiFiClient class to create TCP connections and talk to hosts
+  WiFiClient client;
+#endif
+
+// External function dependencies
+#ifdef DWEET
+  post_dweet();
+#endif
+
+#ifdef THINGSPEAK
+  post_thingspeak();
+#endif
+
+#ifdef INFLUX
+  // SparkFun SEN5x
+  // extern void post_influx(float pm25, float aqi, float tempF, float vocIndex, float humidity);
+  extern boolean post_influx();
+#endif
+
+#ifdef MQTT
+  //extern void mqttConnect();
+  extern int mqttDeviceWiFiUpdate(int rssi);
+  extern int mqttSensorUpdate(uint16_t co2, float tempF, float humidity);
+#endif
+
+// SparkFun SEN5X
+//Create SEN5x sensor instance
+// SensirionI2CSen5x sen5x;
 
 // The used commands use up to 48 bytes. On some Arduinos the default buffer
 // space is not large enough
-#define MAXBUF_REQUIREMENT 48
+// #define MAXBUF_REQUIREMENT 48
 
-#if (defined(I2C_BUFFER_LENGTH) &&                 \
-     (I2C_BUFFER_LENGTH >= MAXBUF_REQUIREMENT)) || \
-    (defined(BUFFER_LENGTH) && BUFFER_LENGTH >= MAXBUF_REQUIREMENT)
-#define USE_PRODUCT_INFO
-#endif
+// #if (defined(I2C_BUFFER_LENGTH) &&                 \
+//      (I2C_BUFFER_LENGTH >= MAXBUF_REQUIREMENT)) || \
+//     (defined(BUFFER_LENGTH) && BUFFER_LENGTH >= MAXBUF_REQUIREMENT)
+// #define USE_PRODUCT_INFO
+// #endif
 
-//Create Instance of SEN5x sensor
-SensirionI2CSen5x sen5x;
+// Adafruit PMSA003I
+//create Plantower sensor instance
+Adafruit_PM25AQI aqi = Adafruit_PM25AQI();
 
-// Use WiFiClient class to create TCP connections and talk to hosts
-WiFiClient client;
+// global variables
 
-/*
- * Need to accumulate several pieces of data to calculate ongoing readings
- *
- * In a moving vehicle good values are a sample delay of 2 seconds and a capture
- * delay (reporting inverval) of 2 minutes.  At a stationary location such as a home
- * weather station good values are a sample delay of 5 seconds and a capture delay
- * of 5 minutes.
- *
- */
-const int sampleDelay = 5;         /* Interval at which temperature sensor is read (in seconds) */
-const int reportDelay = 15;          /* Interval at which samples are averaged & reported (in minutes) */
-const unsigned long reportDelayMs = reportDelay * 60 * 1000L;  /* Calculation interval */
-const unsigned long sampleDelayMs = sampleDelay * 1000L;       /* Sample delay interval */
-unsigned long prevReportMs = 0;  /* Timestamp for measuring elapsed capture time */
-unsigned long prevSampleMs  = 0;  /* Timestamp for measuring elapsed sample time */
-unsigned int numSamples = 0;  /* Number of overall sensor readings over reporting interval */
-unsigned int numReports = 0; /* Number of capture intervals observed */
+// PM sensor data
+typedef struct
+{
+  float massConcentrationPm1p0;
+  float massConcentrationPm2p5;
+  float massConcentrationPm10p0;
 
-float Pm25 = 0;        /* Air Quality reading (PM2.5) over capture interval */
-float CurrentPm25 = 0; /* Current PM2.5 reading from AQI sensor */
-float AvgPm25;         /* Average PM2.5 as reported last capture interval */
+  // SparkFun SEN5x
+  // float massConcentrationPm4p0;
+  // float ambientHumidity;
+  // float ambientTemperature;
+  // float vocIndex;
+  // float noxIndex;  // Not supported by SEN54 (only SEN55)
+
+  // Adafruit PMSA003I
+  // uint16_t pm10_env,       //< Environmental PM1.0
+  //   pm25_env,            //< Environmental PM2.5
+  //   pm100_env;           //< Environmental PM10.0
+  uint16_t particles_03um, //< 0.3um Particle Count
+    particles_05um,      //< 0.5um Particle Count
+    particles_10um,      //< 1.0um Particle Count
+    particles_25um,      //< 2.5um Particle Count
+    particles_50um,      //< 5.0um Particle Count
+    particles_100um;     //< 10.0um Particle Count
+} envData;
+envData sensorData;
+
+// SparkFun SEN5x
+// float humidityTotal = 0;  // running total of humidity over report interval
+// float tempFTotal = 0;     // running total of temperature over report interval
+// float vocTotal = 0;       // running total of VOC over report interval
+// float avgTempF = 0;       // average temperature over report interval         
+// float avgHumidity = 0;    // average humidity over report interval
+// float avgVOC = 0;         // average VOC over report interval
+
+float pm25Total = 0;      // running total of humidity over report interval
+float avgPM25;            // average PM2.5 over report interval
+
+unsigned long prevReportMs = 0;   // Timestamp for measuring elapsed capture time
+unsigned long prevSampleMs  = 0;  // Timestamp for measuring elapsed sample time
+unsigned int numSamples = 0;      // Number of overall sensor readings over reporting interval
+unsigned int numReports = 0;      // Number of capture intervals observed
+
+// ??? where do these come from, and aren't they reversed?
 float MinPm25 = 1999;   /* Observed minimum PM2.5 */
 float MaxPm25 = -99;   /* Observed maximum PM2.5 */
 
-float TemperatureF = 0;
-float CurrentTempF = 0;
-float AvgTempF = 0;
+bool internetAvailable;
 
-float Humidity = 0;
-float CurrentHumidity = 0;
-float AvgHumidity = 0;
+void setup() 
+{
+  // handle Serial first so debugMessage() works
+  #ifdef DEBUG
+    Serial.begin(115200);
+    // wait for serial port connection
+    while (!Serial);
 
-float VocIndex = 0;
-float CurrentVoc = 0;
-float AvgVoc = 0;
+    // Confirm key site configuration parameters
+    debugMessage("PM2.5 monitor started");
+    debugMessage("Client ID: " + String(CLIENT_ID));
+    debugMessage(String(SAMPLE_INTERVAL) + " second sample interval");
+    debugMessage(String(REPORT_INTERVAL) + " minute report interval");
+  #endif
 
-extern void post_influx(float pm25, float aqi, float tempF, float vocIndex, float humidity);
-
-
-void setup() {
-  
-  Serial.begin(115200);
-
-  Serial.print("Sampling delay: ");  Serial.print(sampleDelay); Serial.println(" seconds");
-  Serial.print("Reporting delay: "); Serial.print(reportDelay); Serial.println(" minutes");
-
-
-  // We start by connecting to a WiFi network           
-  WiFi.begin(WIFI_SSID, WIFI_PASS);
-
-  // Give some feedback while we wait...
-  Serial.print("Connecting");
-  while (WiFi.status() != WL_CONNECTED) {
-    delay(250);
-    Serial.print(".");
-  }
-     
-  Serial.println("done");
-  Serial.println("WiFi connected");  
-  Serial.println("IP address: ");
-  Serial.println(WiFi.localIP());
-
-  Serial.println("Sampling...please wait");
-  
-  // Wait ten seconds for sensor to boot up!
-  delay(10000);
-
-
-  Wire.begin();
-  sen5x.begin(Wire);
-  
-  uint16_t error;
-  char errorMessage[256];
-  error = sen5x.deviceReset();
-  if (error) {
-      Serial.print("Error trying to execute deviceReset(): ");
-      errorToString(error, errorMessage, 256);
-      Serial.println(errorMessage);
-  }
-
-// Print SEN55 module information if i2c buffers are large enough
-#ifdef USE_PRODUCT_INFO
-    printSerialNumber();
-    printModuleVersions();
-#endif
-  
-  // set a temperature offset in degrees celsius
-  // By default, the temperature and humidity outputs from the sensor
-  // are compensated for the modules self-heating. If the module is
-  // designed into a device, the temperature compensation might need
-  // to be adapted to incorporate the change in thermal coupling and
-  // self-heating of other device components.
-  //
-  // A guide to achieve optimal performance, including references
-  // to mechanical design-in examples can be found in the app note
-  // “SEN5x – Temperature Compensation Instruction” at www.sensirion.com.
-  // Please refer to those application notes for further information
-  // on the advanced compensation settings used
-  // in `setTemperatureOffsetParameters`, `setWarmStartParameter` and
-  // `setRhtAccelerationMode`.
-  //
-  // Adjust tempOffset to account for additional temperature offsets
-  // exceeding the SEN module's self heating.
-  float tempOffset = 0.0;
-  error = sen5x.setTemperatureOffsetSimple(tempOffset);
-  if (error) {
-      Serial.print("Error trying to execute setTemperatureOffsetSimple(): ");
-      errorToString(error, errorMessage, 256);
-      Serial.println(errorMessage);
-  } else {
-      Serial.print("Temperature Offset set to ");
-      Serial.print(tempOffset);
-      Serial.println(" deg. Celsius");
-  }
-
-  // Start Measurement
-  error = sen5x.startMeasurement();
-  if (error) {
-      Serial.print("Error trying to execute startMeasurement(): ");
-      errorToString(error, errorMessage, 256);
-      Serial.println(errorMessage);
-  }
-
-  Serial.println("AQI sensor found!");
-
+  initSensor();
+  #ifdef WIFI
+    if(networkBegin())
+    {
+      internetAvailable = true;
+    }
+  #endif
   // Remember current clock time
   prevReportMs = prevSampleMs = millis();
 }
 
-void  loop() {
-  uint16_t error;
-  char errorMessage[256];
-  // Read Measurement
-  float massConcentrationPm1p0;
-  float massConcentrationPm2p5;
-  float massConcentrationPm4p0;
-  float massConcentrationPm10p0;
-  float ambientHumidity;
-  float ambientTemperature;
-  float vocIndex;
-  float noxIndex;  // Not supported by SEN54 (only SEN55)
-  
-  unsigned long currentMillis = millis();    // Check current timer value
-  
-  /* See if it is time to read the sensors */
-  if( (currentMillis - prevSampleMs) >= sampleDelayMs) {
-    error = sen5x.readMeasuredValues(
-        massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
-        massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
-        noxIndex);
+void loop()
+{
+  // update current timer value
+  unsigned long currentMillis = millis();
 
-    if (error) {
-        Serial.print("Error trying to execute readMeasuredValues(): ");
-        errorToString(error, errorMessage, 256);
-        Serial.println(errorMessage);
-        prevSampleMs = currentMillis;
-    } 
-    else {
-      // Since we have a sample, count it
-      numSamples ++;  // Since we started at 0...
-  
-      CurrentPm25 = massConcentrationPm2p5;
-      Pm25 +=  CurrentPm25;
-
-      CurrentTempF = 32.0 + (1.8*ambientTemperature);
-      TemperatureF += CurrentTempF;
-
-      CurrentVoc = vocIndex;
-      VocIndex += CurrentVoc;
-
-      CurrentHumidity = ambientHumidity;
-      Humidity += CurrentHumidity;
-  
-      Serial.print("Read data PM25: ");
-      Serial.print(CurrentPm25);
-      Serial.print(" = AQI: ");
-      Serial.print(pm25toAQI(CurrentPm25));
-      Serial.print(", VOC: ");
-      Serial.print(CurrentVoc);
-      Serial.print(" (@ ");
-      Serial.print(CurrentTempF);
-      Serial.print("F, ");
-      Serial.print(CurrentHumidity);
-      Serial.println("%)");
-
-      
-      // Save sample time
-      prevSampleMs = currentMillis;
+  // is it time to read the sensor
+  if((currentMillis - prevSampleMs) >= (SAMPLE_INTERVAL * 1000)) // converting SAMPLE_INTERVAL into milliseconds
+  {
+    if (!readSensor())
+    {
+      // handle error condition
     }
+    numSamples++;
+
+    // // SparkFun SEN5X
+    // // convert temp from C to F
+    // sensorData.ambientTemperature = 32.0 + (1.8*sensorData.ambientTemperature);
+    // tempFTotal += sensorData.Temperature;
+    // humidityTotal += sensorData.ambientHumidity;
+    // vocTotal += sensorData.vocIndex;
+
+    // add to the running totals
+    pm25Total += sensorData.massConcentrationPm2p5;
+
+    debugMessage(String("PM2.5 reading is ") + sensorData.massConcentrationPm2p5 + " or AQI " + pm25toAQI(sensorData.massConcentrationPm2p5));
+  
+    // // SparkFun SEN5X
+    // debugMessage(String("Temp is ") + sensorData.ambientTemperature + " F");
+    // debugMessage(String("Humidity is ") + sensorData.ambientHumidity + "%");
+    // debugMessage(String("VOC level is ") + sensorData.VocIndex);
+
+    // Save sample time
+    prevSampleMs = currentMillis;
   }
-  /* Now check and see if it is time to report averaged values */
-  if( (currentMillis - prevReportMs) >= reportDelayMs) {
 
-    if(numSamples == 0 ) {
-      // Never got any data from the sensor, so need to flag that by dweeting a pm25 of -1 and AQI of 0
-      // Don't bother reporting data to ThingSpeak though (we don't have any!)
-      // (Might still have reasonable max/min values)
-      post_dweet(-1.0,pm25toAQI(MinPm25),pm25toAQI(MaxPm25),0.0,1000.0,-1.0,-1.0);
+  // is it time to report averaged values
+  if((currentMillis - prevReportMs) >= (REPORT_INTERVAL * 60 *1000)) // converting REPORT_INTERVAL into milliseconds
+  {
+    if (numSamples != 0) 
+    {
+      avgPM25 = Pm25 / numSamples;
+      if(avgPM25 > MaxPm25) MaxPm25 = avgPM25;
+      if(avgPM25 < MinPm25) MinPm25 = avgPM25;
 
-      // Reset counters and accumulators
-      prevReportMs = currentMillis;
-      numSamples = 0;
-      Pm25 = 0;
-      TemperatureF = 0;
-      VocIndex = 0;
-      Humidity = 0;
-    }
-    else {
-      AvgPm25 = Pm25 / numSamples;
-      if(AvgPm25 > MaxPm25) MaxPm25 = AvgPm25;
-      if(AvgPm25 < MinPm25) MinPm25 = AvgPm25;
-
-      AvgTempF = TemperatureF / numSamples;
-
-      AvgVoc = VocIndex / numSamples;
-
-      AvgHumidity = Humidity / numSamples;
+      // SparkFun SEN5x
+      // avgTempF = TemperatureF / numSamples;
+      // avgVOC = VocIndex / numSamples;
+      // avgHumidity = Humidity / numSamples;
   
       /* Post both the current readings and historical max/min readings to the web */
-      post_dweet(AvgPm25,pm25toAQI(MinPm25),pm25toAQI(MaxPm25),pm25toAQI(AvgPm25),AvgTempF,AvgVoc,AvgHumidity);
+      #ifdef DWEET
+        post_dweet(avgPM25,pm25toAQI(MinPm25),pm25toAQI(MaxPm25),pm25toAQI(avgPM25),avgTempF,avgVOC,avgHumidity);
+      #endif
   
       // Also post the AQIQ sensor data to ThingSpeak
-      post_thingspeak(AvgPm25,pm25toAQI(MinPm25),pm25toAQI(MaxPm25),pm25toAQI(AvgPm25));
+      #ifdef THINGSPEAK
+        post_thingspeak(avgPM25,pm25toAQI(MinPm25),pm25toAQI(MaxPm25),pm25toAQI(avgPM25));
+      #endif
 
       // And store data to Influx DB (via remote server)    
-      post_influx(AvgPm25,pm25toAQI(AvgPm25),AvgTempF,AvgVoc,AvgHumidity);
+      #ifdef INFLUX
+        // SparkFun SEN5x
+        // post_influx(avgPM25,pm25toAQI(avgPM25),avgTempF,avgVOC,avgHumidity);
+        post_influx();
+      #endif
 
-      
       // Reset counters and accumulators
       prevReportMs = currentMillis;
       numSamples = 0;
-      Pm25 = 0;
-      TemperatureF = 0;
-      VocIndex = 0;
-      Humidity = 0;
+      pm25Total = 0;
+      tempFTotal = 0;
+      vocTotal = 0;
+      humidityTotal = 0;
     }
   }
 }
 
-// Post a dweet to report sensor data readings.  This routine blocks while
-// talking to the network, so may take a while to execute.
-const char* dweet_host = "dweet.io";
-void post_dweet(float pm25, float minaqi, float maxaqi, float aqi, float tempF, float vocIndex, float humidity)
+bool networkBegin()
 {
-  
-  if(WiFi.status() != WL_CONNECTED) {
-    Serial.print("Lost network connection to '");
-    Serial.print(WIFI_SSID);
-    Serial.println("'!");
-    return;
-  }
-  
-  Serial.print("connecting to ");
-  Serial.print(dweet_host);
-  Serial.print(" as ");
-  Serial.println(String(DWEET_DEVICE));
-      
-  // Use our WiFiClient to connect to dweet
-  if (!client.connect(dweet_host, 80)) {
-    Serial.println("connection failed");
-    return;
-  }
+  #ifdef WIFI
+    // set hostname has to come before WiFi.begin
+    WiFi.hostname(CLIENT_ID);
 
-  long rssi = WiFi.RSSI();
-  IPAddress ip = WiFi.localIP();
+    WiFi.begin(WIFI_SSID, WIFI_PASS);
 
-  // Use HTTP post and send a data payload as JSON
-  
-  String postdata = "{\"wifi_rssi\":\""     + String(rssi)           + "\"," +
-                     "\"AQI\":\""           + String(aqi,2)          + "\"," +
-                     "\"address\":\""       + ip.toString()          + "\"," +
-                     "\"temperature\":\""   + String(tempF,1)        + "\"," +
-                     "\"vocIndex\":\""      + String(vocIndex,1)     + "\"," +
-                     "\"humidity\":\""      + String(humidity,1)     + "\"," +
-                     "\"PM25_value\":\""    + String(pm25,2)         + "\"," +
-                     "\"min_AQI\":\""       + String(minaqi,2)       + "\"," + 
-                     "\"max_AQI\":\""       + String(maxaqi,2)       + "\"}";
-  // Note that the dweet device 'name' gets set here, is needed to fetch values
-  client.println("POST /dweet/for/" + String(DWEET_DEVICE) + " HTTP/1.1");
-  client.println("Host: dweet.io");
-  client.println("User-Agent: ESP8266 (orangemoose)/1.0");
-  client.println("Cache-Control: no-cache");
-  client.println("Content-Type: application/json");
-  client.print("Content-Length: ");
-  client.println(postdata.length());
-  client.println();
-  client.println(postdata);
-  Serial.println(postdata);
-
-  delay(1500);  
-  // Read all the lines of the reply from server (if any) and print them to Serial Monitor
-  while(client.available()){
-    String line = client.readStringUntil('\r');
-    Serial.print(line);
-  }
-   
-  Serial.println("closing connection");
-  Serial.println();
+    for (int tries = 1; tries <= CONNECT_ATTEMPT_LIMIT; tries++)
+    // Attempts WiFi connection, and if unsuccessful, re-attempts after CONNECT_ATTEMPT_INTERVAL second delay for CONNECT_ATTEMPT_LIMIT times
+    {
+      if (WiFi.status() == WL_CONNECTED)
+      {
+        debugMessage("WiFi IP address issued from " + WIFI_SSID + " is " + WiFi.localIP().toString());
+        debugMessage("WiFi RSSI is: " + String(getWiFiRSSI()) + " dBm");
+        return true;
+      }
+      debugMessage(String("Connection attempt ") + tries + " of " + CONNECT_ATTEMPT_LIMIT + " to " + WIFI_SSID + " failed, trying again in " + CONNECT_ATTEMPT_INTERVAL + " seconds");
+      // use of delay() OK as this is initialization code
+      delay(CONNECT_ATTEMPT_INTERVAL * 1000); // convered into milliseconds
+    }
+    debugMessage("Failed to connect to WiFi");
+    return false;
+    }
+  #endif
 }
 
-// ThingSpeak data upload
-const char* ts_server = "api.thingspeak.com";
-void post_thingspeak(float pm25, float minaqi, float maxaqi, float aqi) {
-  if (client.connect(ts_server, 80)) {
-    
-    // Measure Signal Strength (RSSI) of Wi-Fi connection
-    long rssi = WiFi.RSSI();
-    Serial.print("RSSI: ");
-    Serial.println(rssi);
+int initSensor()
+{
+  // // SparkFun SEN5X
+  // uint16_t error;
+  // char errorMessage[256];
 
-    // Construct API request body
-    String body = "field1=";
-           body += String(aqi,2);
-           body += "&";
-           body += "field2=";
-           body += String(pm25,2);
-           body += "&";
-           body += "field3=";
-           body += String(maxaqi,2);
-           body += "&";
-           body += "field4=";
-           body += String(minaqi,2);
+  // // Handle two ESP32 I2C ports
+  // #if defined(ARDUINO_ADAFRUIT_QTPY_ESP32S2) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32_PICO)
+  //   Wire1.begin();
+  //   sen5x.begin(Wire1);
+  // #else
+  //   Wire.begin();
+  //   sen5x.begin(Wire);
+  // #endif
+  
+  // error = sen5x.deviceReset();
+  // if (error) 
+  // {
+  //   errorToString(error, errorMessage, 256);
+  //   debugMessage(String(errorMessage) + " error during SEN5x reset");
+  //   return 0;
+  // }
+  
+  // // set a temperature offset in degrees celsius
+  // // By default, the temperature and humidity outputs from the sensor
+  // // are compensated for the modules self-heating. If the module is
+  // // designed into a device, the temperature compensation might need
+  // // to be adapted to incorporate the change in thermal coupling and
+  // // self-heating of other device components.
+  // //
+  // // A guide to achieve optimal performance, including references
+  // // to mechanical design-in examples can be found in the app note
+  // // “SEN5x – Temperature Compensation Instruction” at www.sensirion.com.
+  // // Please refer to those application notes for further information
+  // // on the advanced compensation settings used
+  // // in `setTemperatureOffsetParameters`, `setWarmStartParameter` and
+  // // `setRhtAccelerationMode`.
+  // //
+  // // Adjust tempOffset to account for additional temperature offsets
+  // // exceeding the SEN module's self heating.
+  // float tempOffset = 0.0;
+  // error = sen5x.setTemperatureOffsetSimple(tempOffset);
+  // if (error) {
+  //     errorToString(error, errorMessage, 256);
+  //     debugMessage(String(errorMessage) + " error setting temp offset");
+  // } else {
+  //     debugMessage(String("Temperature Offset set to ") + tempOffset + " degrees C");
+  // }
 
+  // // Start Measurement
+  // error = sen5x.startMeasurement();
+  // if (error) {
+  //     errorToString(error, errorMessage, 256);
+  //     debugMessage(String(errorMessage) + " error during SEN5x startMeasurement");
+  //     return 0;
+  // }
+  // debugMessage("SEN5x initialized");
+  // return 1;
 
-    client.println("POST /update HTTP/1.1");
-    client.println("Host: api.thingspeak.com");
-    client.println("User-Agent: ESP8266 (orangemoose)/1.0");
-    client.println("Connection: close");
-    client.println("X-THINGSPEAKAPIKEY: " + String(THINGS_APIKEY));
-    client.println("Content-Type: application/x-www-form-urlencoded");
-    client.println("Content-Length: " + String(body.length()));
-    client.println("");
-    client.print(body);
-    Serial.println(body);
-
+  // Adafruit PMSA003I
+  if (! aqi.begin_I2C()) 
+  {
+    debugMessage("Could not find PMSA003I sensor");
+    while (1) delay(10);
   }
-  delay(1500);
-    
-  // Read all the lines of the reply from server (if any) and print them to Serial Monitor
-  while(client.available()){
-    String line = client.readStringUntil('\r');
-    Serial.print(line);
-  }
-  client.stop();
+  debugMessage("PMSA003I initialized");
+  return 1;
 }
 
-// Converts pm25 reading to AQI using the AQI Equation
-// (https://forum.airnowtech.org/t/the-aqi-equation/169)
+int readSensor()
+{
+  // // SparkFun SEN5X
+  // uint16_t error;
+  // char errorMessage[256];
+  // error = sen5x.readMeasuredValues(
+  //       sensorData.massConcentrationPm1p0, sensorData.massConcentrationPm2p5, sensorData.massConcentrationPm4p0,
+  //       sensorData.massConcentrationPm10p0, sensorData.ambientHumidity, sensorData.ambientTemperature, sensorData.vocIndex,
+  //       sensorData.noxIndex);
+  // if (error) 
+  // {
+  //     errorToString(error, errorMessage, 256);
+  //     debugMessage(String(errorMessage) + " error during SEN5x read");
+  //     prevSampleMs = currentMillis;
+  //     return 0;
+  // }
+  // // successful read
+  // debugMessage("Successful sensor read");
+  // return 1;
+
+  // Adafruit PMSA003I
+  PM25_AQI_Data data;
+  if (! aqi.read(&data)) 
+  {
+    debugMessage("Could not read PMSA003I sensor data");
+    prevSampleMs = currentMillis;
+    return 0;
+  }
+  // successful read
+  sensorData.massConcentrationPm1p0 = data.pm10_standard;
+  sensorData.massConcentrationPm2p5 = data.pm25_standard;
+  sensorData.massConcentrationPm10p0 = data.pm100_standard;
+  sensorData.particles_03um = data.particles_03um;
+  sensorData.particles_05um = data.particles_05um;
+  sensorData.particles_10um = data.particles_10um;
+  sensorData.particles_25um = data.particles_25m;
+  sensorData.particles_50um = data.particles_50um;
+  sensorData.particles_100um = data.particles_100um;
+  debugMessage("Successful sensor read");
+  return 1;
+}
 
 float pm25toAQI(float pm25)
+// Converts pm25 reading to AQI using the AQI Equation
+// (https://forum.airnowtech.org/t/the-aqi-equation/169)
 {  
   if(pm25 <= 12.0)       return(fmap(pm25,  0.0, 12.0,  0.0, 50.0));
   else if(pm25 <= 35.4)  return(fmap(pm25, 12.1, 35.4, 51.0,100.0));
@@ -431,66 +375,11 @@ float fmap(float x, float xmin, float xmax, float ymin, float ymax)
     return( ymin + ((x - xmin)*(ymax-ymin)/(xmax - xmin)));
 }
 
-void printModuleVersions() {
-    uint16_t error;
-    char errorMessage[256];
-
-    unsigned char productName[32];
-    uint8_t productNameSize = 32;
-
-    error = sen5x.getProductName(productName, productNameSize);
-
-    if (error) {
-        Serial.print("Error trying to execute getProductName(): ");
-        errorToString(error, errorMessage, 256);
-        Serial.println(errorMessage);
-    } else {
-        Serial.print("ProductName:");
-        Serial.println((char*)productName);
-    }
-
-    uint8_t firmwareMajor;
-    uint8_t firmwareMinor;
-    bool firmwareDebug;
-    uint8_t hardwareMajor;
-    uint8_t hardwareMinor;
-    uint8_t protocolMajor;
-    uint8_t protocolMinor;
-
-    error = sen5x.getVersion(firmwareMajor, firmwareMinor, firmwareDebug,
-                             hardwareMajor, hardwareMinor, protocolMajor,
-                             protocolMinor);
-    if (error) {
-        Serial.print("Error trying to execute getVersion(): ");
-        errorToString(error, errorMessage, 256);
-        Serial.println(errorMessage);
-    } else {
-        Serial.print("Firmware: ");
-        Serial.print(firmwareMajor);
-        Serial.print(".");
-        Serial.print(firmwareMinor);
-        Serial.print(", ");
-
-        Serial.print("Hardware: ");
-        Serial.print(hardwareMajor);
-        Serial.print(".");
-        Serial.println(hardwareMinor);
-    }
-}
-
-void printSerialNumber() {
-    uint16_t error;
-    char errorMessage[256];
-    unsigned char serialNumber[32];
-    uint8_t serialNumberSize = 32;
-
-    error = sen5x.getSerialNumber(serialNumber, serialNumberSize);
-    if (error) {
-        Serial.print("Error trying to execute getSerialNumber(): ");
-        errorToString(error, errorMessage, 256);
-        Serial.println(errorMessage);
-    } else {
-        Serial.print("SerialNumber:");
-        Serial.println((char*)serialNumber);
-    }
+void debugMessage(String messageText)
+// wraps Serial.println as #define conditional
+{
+#ifdef DEBUG
+  Serial.println(messageText);
+  Serial.flush();  // Make sure the message gets output (before any sleeping...)
+#endif
 }

--- a/Feather_AQI_Monitor_SEN54.ino
+++ b/Feather_AQI_Monitor_SEN54.ino
@@ -114,9 +114,15 @@ int rssi;
 #endif
 
 #ifdef MQTT
-  //extern void mqttConnect();
+  // MQTT interface depends on the underlying network client object, which is defined and
+  // managed here (so needs to be defined here).
+  #include <Adafruit_MQTT.h>
+  #include <Adafruit_MQTT_Client.h>
+  Adafruit_MQTT_Client pm25_mqtt(&client, MQTT_BROKER, MQTT_PORT, CLIENT_ID, MQTT_USER, MQTT_PASS);
+
+  // Adafruit PMSA003I
   extern int mqttDeviceWiFiUpdate(int rssi);
-  extern int mqttSensorUpdate(uint16_t co2, float tempF, float humidity);
+  extern int mqttSensorUpdate(float pm25, float aqi);
 #endif
 
 void setup() 
@@ -220,6 +226,12 @@ void loop()
         // post_influx(avgPM25,pm25toAQI(avgPM25),avgTempF,avgVOC,avgHumidity);
         // Adafruit PMSA003I 
         post_influx(avgPM25, pm25toAQI(avgPM25), rssi);
+      #endif
+
+      #ifdef MQTT
+        // Adafruit PMSA003I
+        mqttDeviceWiFiUpdate(rssi);
+        mqttSensorUpdate(avgPM25, pm25toAQI(avgPM25));
       #endif
 
       // Reset counters and accumulators

--- a/config.h
+++ b/config.h
@@ -1,0 +1,65 @@
+/*
+  Project Name:   PM2.5
+  Description:    Regularly sample and log PM 2.5 levels
+
+  See README.md for target information and revision history
+*/
+
+// Step 1: Set conditional compile flags
+//#define DEBUG     // Output to serial port
+#define WIFI        // use WiFi
+//#define MQTT        // log sensor data to MQTT broker
+#define INFLUX      // Log data to InfluxDB server
+// #define DWEET       // Log data to Dweet service
+// #define THINGSPEAK  // Log data to ThingSpeak
+
+const int SAMPLE_INTERVAL = 5;  // sample interval for sensor in seconds
+const int REPORT_INTERVAL = 15; // Interval at which samples are averaged & reported in minutes)
+
+const int CONNECT_ATTEMPT_LIMIT = 3;      // max connection attempts to internet services
+const int CONNECT_ATTEMPT_INTERVAL = 10;  // seconds between internet service connect attempts
+
+// set client ID; used by mqtt and wifi
+#define CLIENT_ID "RCO2"
+
+#ifdef MQTT
+  // Adafruit I/O
+  // structure: username/feeds/groupname.feedname or username/feeds/feedname
+  // e.g. #define MQTT_PUB_TOPIC1   "sircoolio/feeds/pocket-office.temperature"
+
+  // structure: site/room/device/data 
+  #define MQTT_PUB_TOPIC1   "7828/demo/rco2/temperature"
+  #define MQTT_PUB_TOPIC2   "7828/demo/rco2/humidity"
+  #define MQTT_PUB_TOPIC3   "7828/demo/rco2/co2"
+  #define MQTT_PUB_TOPIC5   "7828/demo/rco2/battery-voltage"
+  #define MQTT_PUB_TOPIC6   "7828/demo/rco2/rssi"
+#endif
+
+#ifdef INFLUX  
+  // Name of Measurements expected/used in the Influx DB.
+  #define INFLUX_ENV_MEASUREMENT "weather"  // Used for environmental sensor data
+  #define INFLUX_DEV_MEASUREMENT "device"   // Used for logging AQI device data (e.g. battery)
+  
+  // Standard set of tag values used for each sensor data point stored to InfluxDB.  Reuses
+  // CLIENT_ID as defined anove here in config.h as well as device location (e.g., room in 
+  // the house) and site (indoors vs. outdoors, typically).
+
+  // #define DEVICE_LOCATION "test"
+  #define DEVICE_LOCATION "RCO2-demo"
+  //#define DEVICE_LOCATION "kitchen"
+  // #define DEVICE_LOCATION "cellar"
+  // #define DEVICE_LOCATION "lab-office"
+  // #define DEVICE_LOCATION "master bedroom"
+  // #define DEVICE_LOCATION "pocket-office"
+
+  #define DEVICE_SITE "indoor"
+  #define DEVICE_TYPE "air quality"
+#endif
+
+// Post data to the internet via dweet.io.  Set DWEET_DEVICE to be a
+// unique name you want associated with this reporting device, allowing
+// data to be easily retrieved through the web or Dweet's REST API.
+#ifdef DWEET
+  #define DWEET_HOST "dweet.io"   // Typically dweet.io
+  #define DWEET_DEVICE "makerhour-airquality"  // Must be unique across all of dweet.io
+#endif

--- a/config.h
+++ b/config.h
@@ -7,7 +7,6 @@
 
 // Step 1: Set conditional compile flags
 #define DEBUG     // Output to serial port
-#define WIFI        // use WiFi
 #define MQTT        // log sensor data to MQTT broker
 #define INFLUX      // Log data to InfluxDB server
 // #define DWEET       // Log data to Dweet service
@@ -22,20 +21,23 @@
 #endif
 
 const int CONNECT_ATTEMPT_LIMIT = 3;      // max connection attempts to internet services
-const int CONNECT_ATTEMPT_INTERVAL = 10;  // seconds between internet service connect attempts
+const int CONNECT_ATTEMPT_INTERVAL = 5;  // seconds between internet service connect attempts
 
 // set client ID; used by mqtt and wifi
-#define CLIENT_ID "RCO2"
+#define CLIENT_ID "PM25"
 
 #ifdef MQTT
   // Adafruit I/O
   // structure: username/feeds/groupname.feedname or username/feeds/feedname
-  // e.g. #define MQTT_PUB_TOPIC1   "sircoolio/feeds/pocket-office.temperature"
+  // e.g. #define MQTT_PUB_TEMPF   "sircoolio/feeds/pocket-office.tempf"
 
   // structure: site/room/device/data 
-  #define MQTT_PUB_TOPIC1   "7828/demo/pm25/pm25"
-  #define MQTT_PUB_TOPIC2   "7828/demo/pm25/aqi"
-  #define MQTT_PUB_TOPIC3   "7828/demo/pm25/rssi"
+  #define MQTT_PUB_PM25       "7828/demo/pm25/pm25"
+  #define MQTT_PUB_AQI        "7828/demo/pm25/aqi"
+  #define MQTT_PUB_TEMPF      "7828/demo/pm25/tempf"
+  #define MQTT_PUB_VOC        "7828/demo/pm25/vocindex"
+  #define MQTT_PUB_HUMIDITY   "7828/demo/pm25/humidity"
+  #define MQTT_PUB_RSSI       "7828/demo/pm25/rssi"
 #endif
 
 #ifdef INFLUX  

--- a/config.h
+++ b/config.h
@@ -6,15 +6,20 @@
 */
 
 // Step 1: Set conditional compile flags
-//#define DEBUG     // Output to serial port
-#define WIFI        // use WiFi
+#define DEBUG     // Output to serial port
+// #define WIFI        // use WiFi
 //#define MQTT        // log sensor data to MQTT broker
-#define INFLUX      // Log data to InfluxDB server
+// #define INFLUX      // Log data to InfluxDB server
 // #define DWEET       // Log data to Dweet service
 // #define THINGSPEAK  // Log data to ThingSpeak
 
-const int SAMPLE_INTERVAL = 5;  // sample interval for sensor in seconds
-const int REPORT_INTERVAL = 15; // Interval at which samples are averaged & reported in minutes)
+#ifdef DEBUG
+  const int SAMPLE_INTERVAL = 5;  // sample interval for sensor in seconds
+  const int REPORT_INTERVAL = 1; // Interval at which samples are averaged & reported in minutes)
+#else
+  const int SAMPLE_INTERVAL = 30;  // sample interval for sensor in seconds
+  const int REPORT_INTERVAL = 15; // Interval at which samples are averaged & reported in minutes)
+#endif
 
 const int CONNECT_ATTEMPT_LIMIT = 3;      // max connection attempts to internet services
 const int CONNECT_ATTEMPT_INTERVAL = 10;  // seconds between internet service connect attempts

--- a/config.h
+++ b/config.h
@@ -8,7 +8,7 @@
 // Step 1: Set conditional compile flags
 #define DEBUG     // Output to serial port
 #define WIFI        // use WiFi
-//#define MQTT        // log sensor data to MQTT broker
+#define MQTT        // log sensor data to MQTT broker
 #define INFLUX      // Log data to InfluxDB server
 // #define DWEET       // Log data to Dweet service
 // #define THINGSPEAK  // Log data to ThingSpeak
@@ -33,11 +33,9 @@ const int CONNECT_ATTEMPT_INTERVAL = 10;  // seconds between internet service co
   // e.g. #define MQTT_PUB_TOPIC1   "sircoolio/feeds/pocket-office.temperature"
 
   // structure: site/room/device/data 
-  #define MQTT_PUB_TOPIC1   "7828/demo/rco2/temperature"
-  #define MQTT_PUB_TOPIC2   "7828/demo/rco2/humidity"
-  #define MQTT_PUB_TOPIC3   "7828/demo/rco2/co2"
-  #define MQTT_PUB_TOPIC5   "7828/demo/rco2/battery-voltage"
-  #define MQTT_PUB_TOPIC6   "7828/demo/rco2/rssi"
+  #define MQTT_PUB_TOPIC1   "7828/demo/pm25/pm25"
+  #define MQTT_PUB_TOPIC2   "7828/demo/pm25/aqi"
+  #define MQTT_PUB_TOPIC3   "7828/demo/pm25/rssi"
 #endif
 
 #ifdef INFLUX  

--- a/config.h
+++ b/config.h
@@ -7,9 +7,9 @@
 
 // Step 1: Set conditional compile flags
 #define DEBUG     // Output to serial port
-// #define WIFI        // use WiFi
+#define WIFI        // use WiFi
 //#define MQTT        // log sensor data to MQTT broker
-// #define INFLUX      // Log data to InfluxDB server
+#define INFLUX      // Log data to InfluxDB server
 // #define DWEET       // Log data to Dweet service
 // #define THINGSPEAK  // Log data to ThingSpeak
 
@@ -49,8 +49,8 @@ const int CONNECT_ATTEMPT_INTERVAL = 10;  // seconds between internet service co
   // CLIENT_ID as defined anove here in config.h as well as device location (e.g., room in 
   // the house) and site (indoors vs. outdoors, typically).
 
-  // #define DEVICE_LOCATION "test"
-  #define DEVICE_LOCATION "RCO2-demo"
+  #define DEVICE_LOCATION "PM25-test"
+  // #define DEVICE_LOCATION "PM25-demo"
   //#define DEVICE_LOCATION "kitchen"
   // #define DEVICE_LOCATION "cellar"
   // #define DEVICE_LOCATION "lab-office"
@@ -58,7 +58,7 @@ const int CONNECT_ATTEMPT_INTERVAL = 10;  // seconds between internet service co
   // #define DEVICE_LOCATION "pocket-office"
 
   #define DEVICE_SITE "indoor"
-  #define DEVICE_TYPE "air quality"
+  #define DEVICE_TYPE "pm25"
 #endif
 
 // Post data to the internet via dweet.io.  Set DWEET_DEVICE to be a

--- a/post_dweet.cpp
+++ b/post_dweet.cpp
@@ -1,0 +1,143 @@
+// this is a stub to add DWEET publish support to PM2.5
+// code comes from Air Quality project
+// this code has not been updated or tested
+
+// Post a dweet to report sensor data readings.  This routine blocks while
+// talking to the network, so may take a while to execute.
+
+#ifdef DWEET
+
+// David's original PM2.5 dweet code
+const char* dweet_host = "dweet.io";
+void post_dweet(float pm25, float minaqi, float maxaqi, float aqi, float tempF, float vocIndex, float humidity)
+{
+  
+  if(WiFi.status() != WL_CONNECTED) {
+    Serial.print("Lost network connection to '");
+    Serial.print(WIFI_SSID);
+    Serial.println("'!");
+    return;
+  }
+  
+  Serial.print("connecting to ");
+  Serial.print(dweet_host);
+  Serial.print(" as ");
+  Serial.println(String(DWEET_DEVICE));
+      
+  // Use our WiFiClient to connect to dweet
+  if (!client.connect(dweet_host, 80)) {
+    Serial.println("connection failed");
+    return;
+  }
+
+  long rssi = WiFi.RSSI();
+  IPAddress ip = WiFi.localIP();
+
+  // Use HTTP post and send a data payload as JSON
+  
+  String postdata = "{\"wifi_rssi\":\""     + String(rssi)           + "\"," +
+                     "\"AQI\":\""           + String(aqi,2)          + "\"," +
+                     "\"address\":\""       + ip.toString()          + "\"," +
+                     "\"temperature\":\""   + String(tempF,1)        + "\"," +
+                     "\"vocIndex\":\""      + String(vocIndex,1)     + "\"," +
+                     "\"humidity\":\""      + String(humidity,1)     + "\"," +
+                     "\"PM25_value\":\""    + String(pm25,2)         + "\"," +
+                     "\"min_AQI\":\""       + String(minaqi,2)       + "\"," + 
+                     "\"max_AQI\":\""       + String(maxaqi,2)       + "\"}";
+  // Note that the dweet device 'name' gets set here, is needed to fetch values
+  client.println("POST /dweet/for/" + String(DWEET_DEVICE) + " HTTP/1.1");
+  client.println("Host: dweet.io");
+  client.println("User-Agent: ESP8266 (orangemoose)/1.0");
+  client.println("Cache-Control: no-cache");
+  client.println("Content-Type: application/json");
+  client.print("Content-Length: ");
+  client.println(postdata.length());
+  client.println();
+  client.println(postdata);
+  Serial.println(postdata);
+
+  delay(1500);  
+  // Read all the lines of the reply from server (if any) and print them to Serial Monitor
+  while(client.available()){
+    String line = client.readStringUntil('\r');
+    Serial.print(line);
+  }
+   
+  Serial.println("closing connection");
+  Serial.println();
+}
+
+
+// the post_dweet function from Air Quality, partially modified to send PM 2.5 data
+
+  #include "Arduino.h"
+
+  // hardware and internet configuration parameters
+  #include "config.h"
+
+  #include <HTTPClient.h> 
+
+  // Shared helper functions called from project files
+  extern void debugMessage(String messageText);
+
+  void post_dweet(float pm25, float minaqi, float maxaqi, float aqi, float tempF, float vocIndex, float humidity)
+  {
+    if(WiFi.status() != WL_CONNECTED)
+    {
+      debugMessage("Lost network connection to '" + String(WIFI_SSID) + "'!");
+      return;
+    }
+    debugMessage("connecting to " + String(DWEET_HOST) + " as " + String(DWEET_DEVICE));
+
+    String dweeturl = "http://" + String(DWEET_HOST) + "/dweet/for/" + String(DWEET_DEVICE);
+
+    // Use our WiFiClient to connect to dweet
+    if (!client.connect(dweet_host, 80))
+    {
+      Serial.println("connection failed");
+      return;
+    }
+
+    // Use HTTP class to publish dweet
+    HTTPClient dweetio;
+    dweetio.begin(client,dweeturl);  
+    dweetio.addHeader("Content-Type", "application/json");
+
+
+    // Use HTTP post and send a data payload as JSON
+    String device_info = "{\"rssi\":\""   + String(rssi)        + "\"," +
+                         "\"ipaddr\":\"" + WiFi.localIP().toString()  + "\",";
+    String battery_info;
+    if((battpct !=10000)&&(battv != 10000)) {
+      battery_info = "\"battery_percent\":\"" + String(battpct) + "\"," +
+                     "\"battery_voltage\":\"" + String(battv)   + "\",";
+    }
+    else {
+      battery_info = "";
+    }
+
+    String sensor_info;
+    if (co2 !=10000)
+    {
+      sensor_info = "\"co2\":\""         + String(co2)             + "\"," +
+                         "\"temperature\":\"" + String(tempF, 2)         + "\"," +
+                         "\"humidity\":\""    + String(humidity, 2)      + "\"}";
+    }
+    else
+    {
+      sensor_info = "\"temperature\":\"" + String(tempF, 2)         + "\"," +
+                         "\"humidity\":\""    + String(humidity, 2)      + "\"}";
+    }
+
+    String postdata = device_info + battery_info + sensor_info;
+    int httpCode = aq_network.httpPOSTRequest(dweeturl,"application/json",postdata);
+    
+    // httpCode will be negative on error, but HTTP status might indicate failure
+    if (httpCode > 0) {
+      // HTTP POST complete, print result code
+      debugMessage("HTTP POST [dweet.io], result code: " + String(httpCode) );
+    } else {
+      debugMessage("HTTP POST [dweet.io] failed, result code: " + String(httpCode));
+    }
+  }
+#endif

--- a/post_influx.cpp
+++ b/post_influx.cpp
@@ -38,77 +38,82 @@
   InfluxDBClient dbclient(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN);
   #endif
 
-  // InfluxDB Data point, binds to InfluxDB 'measurement' to use for data. See config.h for value used
-  Point dbenvdata(INFLUX_ENV_MEASUREMENT);
-  Point dbdevdata(INFLUX_DEV_MEASUREMENT);
 
   // Post data to Influx DB using the connection established during setup
-  boolean post_influx(float pm25, float aqi, int rssi)
+  boolean post_influx(float pm25, float aqi, float tempF, float vocIndex, float humidity, int rssi)
   {
-    Serial.println("Saving data to Influx");
-    #ifdef INFLUX_V1
-      // Set InfluxDB v1.X authentication params using values defined in secrets.h.  Not needed as such
-      // for InfluxDB v2.X (which uses a token-based scheme via the constructor).
-      dbclient.setConnectionParamsV1(INFLUXDB_URL, INFLUXDB_DB_NAME, INFLUXDB_USER, INFLUXDB_PASSWORD);
-    #endif
-    
-    // Add constant Influx data point tags - only do once, will be added to all individual data points
-    // Modify if required to reflect your InfluxDB data model (and set values in config.h)
-    // First for environmental data
-    dbenvdata.addTag("device", DEVICE_TYPE);
-    dbenvdata.addTag("location", DEVICE_LOCATION);
-    dbenvdata.addTag("site", DEVICE_SITE);
-    // And again for device data
-    dbdevdata.addTag("device", DEVICE_TYPE);
-    dbdevdata.addTag("location", DEVICE_LOCATION);
-    dbdevdata.addTag("site", DEVICE_SITE);
+    bool result = false;
 
-    // If confirmed connection to InfluxDB server, store our data values (with retries)
-    boolean dbsuccess = false;
-    int dbtries;
-    for (dbtries = 1; dbtries <= CONNECT_ATTEMPT_LIMIT; dbtries++) {
-      debugMessage(String("InfluxDB connection attempt ") + dbtries + " of "+ CONNECT_ATTEMPT_LIMIT + " in " + String(CONNECT_ATTEMPT_INTERVAL) + " seconds");
-      if (dbclient.validateConnection()) {
-        debugMessage("Connected to InfluxDB: " + dbclient.getServerUrl());
-        dbsuccess = true;
-        break;
-      }
-      delay(CONNECT_ATTEMPT_INTERVAL*1000);
-    }
-    if(dbsuccess == false) {
-      debugMessage("InfluxDB connection failed: " + dbclient.getLastErrorMessage());
-      return(false);
-    }
-    else 
+    // InfluxDB Data point, binds to InfluxDB 'measurement' to use for data. See config.h for value used
+    Point dbenvdata(INFLUX_ENV_MEASUREMENT);
+    Point dbdevdata(INFLUX_DEV_MEASUREMENT);
+
+    if (internetAvailable)
     {
-      // Connected, so store sensor values into timeseries data point
-      dbenvdata.clearFields();
-      // Report sensor readings
-      dbenvdata.addField("pm25", pm25);
-      dbenvdata.addField("aqi", aqi);
-      debugMessage("Writing: " + dbclient.pointToLineProtocol(dbenvdata));
-      // Write point via connection to InfluxDB host
-      if (!dbclient.writePoint(dbenvdata)) {
-        debugMessage("InfluxDB write failed: " + dbclient.getLastErrorMessage());
-        dbsuccess = false;  // So close...
-      }
+      #ifdef INFLUX_V1
+        // Set InfluxDB v1.X authentication params using values defined in secrets.h.  Not needed as such
+        // for InfluxDB v2.X (which uses a token-based scheme via the constructor).
+        dbclient.setConnectionParamsV1(INFLUXDB_URL, INFLUXDB_DB_NAME, INFLUXDB_USER, INFLUXDB_PASSWORD);
+      #endif
+      
+      // Add constant Influx data point tags - only do once, will be added to all individual data points
+      // Modify if required to reflect your InfluxDB data model (and set values in config.h)
+      // First for environmental data
+      dbenvdata.addTag("device", DEVICE_TYPE);
+      dbenvdata.addTag("location", DEVICE_LOCATION);
+      dbenvdata.addTag("site", DEVICE_SITE);
+      // And again for device data
+      dbdevdata.addTag("device", DEVICE_TYPE);
+      dbdevdata.addTag("location", DEVICE_LOCATION);
+      dbdevdata.addTag("site", DEVICE_SITE);
 
-      // Now store device information 
-      dbdevdata.clearFields();
-      // Report device readings
-      if (internetAvailable)
+      // Attempts influxDB connection, and if unsuccessful, re-attempts after CONNECT_ATTEMPT_INTERVAL second delay for CONNECT_ATTEMPT_LIMIT times
+      for (int tries = 1; tries <= CONNECT_ATTEMPT_LIMIT; tries++) {
+        if (dbclient.validateConnection()) {
+          debugMessage(String("Connected to InfluxDB: ") + dbclient.getServerUrl());
+          result = true;
+          break;
+        }
+        debugMessage(String("influxDB connection attempt ") + tries + " of " + CONNECT_ATTEMPT_LIMIT + " failed with error msg: " + dbclient.getLastErrorMessage());
+        delay(CONNECT_ATTEMPT_INTERVAL*1000);
+      }
+      if (result)
       {
+        // Connected, so store sensor values into timeseries data points
+        dbenvdata.clearFields();
+        // Report sensor readings
+        dbenvdata.addField("pm25", pm25);
+        dbenvdata.addField("aqi", aqi);
+        dbenvdata.addField("tempF", aqi);
+        dbenvdata.addField("vocIndex", aqi);
+        dbenvdata.addField("humidity", aqi);
+        // Write point via connection to InfluxDB host
+        if (!dbclient.writePoint(dbenvdata)) {
+          debugMessage(String("InfluxDB write failed: ") + dbclient.getLastErrorMessage());
+          result = false;
+        }
+        else
+        {
+          debugMessage(String("InfluxDB write success: ") + dbclient.pointToLineProtocol(dbenvdata));
+        }
+
+        // Now store device information 
+        dbdevdata.clearFields();
+        // Report device readings
         dbdevdata.addField("rssi", rssi);
         // Write point via connection to InfluxDB host
-        debugMessage("Writing: " + dbclient.pointToLineProtocol(dbdevdata));
         if (!dbclient.writePoint(dbdevdata))
         {
-          debugMessage("InfluxDB write failed: " + dbclient.getLastErrorMessage());
-          dbsuccess = false;  // So close...
+          debugMessage(String("InfluxDB write failed: ") + dbclient.getLastErrorMessage());
+          result = false;
         }
+        else
+        {
+          debugMessage(String("InfluxDB write success: ") + dbclient.pointToLineProtocol(dbdevdata));
+        }
+      dbclient.flushBuffer();  // Clear pending writes
       }
-      dbclient.flushBuffer();  // Clear pending writes (before going to sleep)
     }
-    return(dbsuccess);
+    return(result);
   }
 #endif

--- a/post_influx.cpp
+++ b/post_influx.cpp
@@ -1,61 +1,117 @@
+// this is a stub to add Influx publish support to PM2.5
+// code comes from Air Quality project
+// this code has not been updated or tested
+
 #include "Arduino.h"
 
-// private credentials for network and external services
+// hardware and internet configuration parameters
+#include "config.h"
+// private credentials for network, MQTT, weather provider
 #include "secrets.h"
 
-#include <InfluxDbClient.h>
-// InfluxDB setup.  See config.h and secrets.h for site-specific settings
+// Only compile if InfluxDB enabled
+#ifdef INFLUX
 
+// Shared helper function
+extern void debugMessage(String messageText);
+
+// Status variables shared across various functions
+extern bool batteryVoltageAvailable;
+extern bool internetAvailable;
+
+#include <InfluxDbClient.h>
+
+// InfluxDB setup.  See config.h and secrets.h for site-specific settings.  Both InfluxDB v1.X
+// and v2.X are supported here depending on configuration settings in secrets.h.  Code here
+// reflects a number of presumptions about the data schema and InfluxDB configuration:
+//
+
+#ifdef INFLUX_V1
 // InfluxDB client instance for InfluxDB 1
 InfluxDBClient dbclient(INFLUXDB_URL, INFLUXDB_DB_NAME);
+#endif
+
+#ifdef INFLUX_V2
+// InfluxDB client instance for InfluxDB 2
+InfluxDBClient dbclient(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN);
+#endif
+
+// InfluxDB Data point, binds to InfluxDB 'measurement' to use for data. See config.h for value used
+Point dbenvdata(INFLUX_ENV_MEASUREMENT);
+Point dbdevdata(INFLUX_DEV_MEASUREMENT);
 
 // Post data to Influx DB using the connection established during setup
-// Operates over the network, so may take uint16_ta while to execute.
-void post_influx(float pm25, float aqi, float tempF, float vocIndex, float humidity)
+// Operates over the network, so may take a while to execute.
+boolean post_influx(uint16_t co2, float tempF, float humidity, float battery_v, int rssi)
 {
   Serial.println("Saving data to Influx");
-  // Set InfluxDB 1 authentication params using values defined in secrets.h
-  dbclient.setConnectionParamsV1(INFLUXDB_URL, INFLUXDB_DB_NAME, INFLUXDB_USER, INFLUXDB_PASSWORD);
+  #ifdef INFLUX_V1
+    // Set InfluxDB v1.X authentication params using values defined in secrets.h.  Not needed as such
+    // for InfluxDB v2.X (which uses a token-based scheme via the constructor).
+    dbclient.setConnectionParamsV1(INFLUXDB_URL, INFLUXDB_DB_NAME, INFLUXDB_USER, INFLUXDB_PASSWORD);
+  #endif
   
-  // InfluxDB Data points, binds to InfluxDB 'measurement' to use for data
-  Point dbenvdata("weather");  // Weather data
-
   // Add constant Influx data point tags - only do once, will be added to all individual data points
   // Modify if required to reflect your InfluxDB data model (and set values in config.h)
-  // Tags for environmental data (weather):
-  dbenvdata.addTag("device", DEVICE_NAME);
+  // First for environmental data
+  dbenvdata.addTag("device", DEVICE_TYPE);
   dbenvdata.addTag("location", DEVICE_LOCATION);
   dbenvdata.addTag("site", DEVICE_SITE);
+  // And again for device data
+  dbdevdata.addTag("device", DEVICE_TYPE);
+  dbdevdata.addTag("location", DEVICE_LOCATION);
+  dbdevdata.addTag("site", DEVICE_SITE);
 
   // If confirmed connection to InfluxDB server, store our data values (with retries)
   boolean dbsuccess = false;
-  uint8_t dbtries;
-  for (dbtries = 1; dbtries <= 5; dbtries++) {
+  int dbtries;
+  for (dbtries = 1; dbtries <= CONNECT_ATTEMPT_LIMIT; dbtries++) {
+    debugMessage(String("InfluxDB connection attempt ") + dbtries + " of "+ CONNECT_ATTEMPT_LIMIT + " in " + String(CONNECT_ATTEMPT_INTERVAL) + " seconds");
     if (dbclient.validateConnection()) {
-      Serial.println("Connected to InfluxDB: " + dbclient.getServerUrl());
+      debugMessage("Connected to InfluxDB: " + dbclient.getServerUrl());
       dbsuccess = true;
       break;
     }
-    delay(dbtries * 10000); // Waiting longer each time we check for status
+    delay(CONNECT_ATTEMPT_INTERVAL*1000);
   }
   if(dbsuccess == false) {
-    Serial.println("InfluxDB connection failed: " + dbclient.getLastErrorMessage());
-    return;
+    debugMessage("InfluxDB connection failed: " + dbclient.getLastErrorMessage());
+    return(false);
   }
-  else {
-    // Connected, so store measured values into timeseries data point
-    // First, the environmental data (weather)
+  else 
+  {
+    // Connected, so store sensor values into timeseries data point
     dbenvdata.clearFields();
     // Report sensor readings
-    dbenvdata.addField("pm25", pm25);
-    dbenvdata.addField("aqi", aqi);
-    dbenvdata.addField("vocindex", vocIndex);
-    dbenvdata.addField("humidity",humidity);
-    dbenvdata.addField("temperature",tempF);
-    Serial.println("Writing: " + dbclient.pointToLineProtocol(dbenvdata));
+    dbenvdata.addField("temperature", tempF);
+    dbenvdata.addField("humidity", humidity);
+    dbenvdata.addField("co2", co2);
+    debugMessage("Writing: " + dbclient.pointToLineProtocol(dbenvdata));
     // Write point via connection to InfluxDB host
     if (!dbclient.writePoint(dbenvdata)) {
-      Serial.println("InfluxDB weather write failed: " + dbclient.getLastErrorMessage());
+      debugMessage("InfluxDB write failed: " + dbclient.getLastErrorMessage());
+      dbsuccess = false;  // So close...
     }
+
+    // Now store device information 
+    dbdevdata.clearFields();
+    // Report device readings
+    if (batteryVoltageAvailable)
+      dbdevdata.addField("battery_volts", battery_v);
+    if (internetAvailable)
+      dbdevdata.addField("rssi", rssi);
+    if ((batteryVoltageAvailable) || (internetAvailable))
+    {
+      // Write point via connection to InfluxDB host
+      debugMessage("Writing: " + dbclient.pointToLineProtocol(dbdevdata));
+      if (!dbclient.writePoint(dbdevdata))
+      {
+        debugMessage("InfluxDB write failed: " + dbclient.getLastErrorMessage());
+        dbsuccess = false;  // So close...
+      }
+    }
+    dbclient.flushBuffer();  // Clear pending writes (before going to sleep)
   }
+  return(dbsuccess);
 }
+#endif

--- a/post_influx.cpp
+++ b/post_influx.cpp
@@ -1,117 +1,114 @@
-// this is a stub to add Influx publish support to PM2.5
-// code comes from Air Quality project
-// this code has not been updated or tested
+/*
+  Project Name:   PM2.5
+  Description:    write PM2.5 sensor data to InfluxDB
 
-#include "Arduino.h"
+  See README.md for target information and revision history
+*/
 
-// hardware and internet configuration parameters
-#include "config.h"
-// private credentials for network, MQTT, weather provider
-#include "secrets.h"
+  #include "Arduino.h"
+
+  // hardware and internet configuration parameters
+  #include "config.h"
+  // private credentials for network, MQTT, weather provider
+  #include "secrets.h"
 
 // Only compile if InfluxDB enabled
 #ifdef INFLUX
 
-// Shared helper function
-extern void debugMessage(String messageText);
+  // Shared helper function
+  extern void debugMessage(String messageText);
 
-// Status variables shared across various functions
-extern bool batteryVoltageAvailable;
-extern bool internetAvailable;
+  // Status variables shared across various functions
+  extern bool internetAvailable;
 
-#include <InfluxDbClient.h>
+  #include <InfluxDbClient.h>
 
-// InfluxDB setup.  See config.h and secrets.h for site-specific settings.  Both InfluxDB v1.X
-// and v2.X are supported here depending on configuration settings in secrets.h.  Code here
-// reflects a number of presumptions about the data schema and InfluxDB configuration:
-//
+  // InfluxDB setup.  See config.h and secrets.h for site-specific settings.  Both InfluxDB v1.X
+  // and v2.X are supported here depending on configuration settings in secrets.h.  Code here
+  // reflects a number of presumptions about the data schema and InfluxDB configuration:
+  //
 
-#ifdef INFLUX_V1
-// InfluxDB client instance for InfluxDB 1
-InfluxDBClient dbclient(INFLUXDB_URL, INFLUXDB_DB_NAME);
-#endif
-
-#ifdef INFLUX_V2
-// InfluxDB client instance for InfluxDB 2
-InfluxDBClient dbclient(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN);
-#endif
-
-// InfluxDB Data point, binds to InfluxDB 'measurement' to use for data. See config.h for value used
-Point dbenvdata(INFLUX_ENV_MEASUREMENT);
-Point dbdevdata(INFLUX_DEV_MEASUREMENT);
-
-// Post data to Influx DB using the connection established during setup
-// Operates over the network, so may take a while to execute.
-boolean post_influx(uint16_t co2, float tempF, float humidity, float battery_v, int rssi)
-{
-  Serial.println("Saving data to Influx");
   #ifdef INFLUX_V1
-    // Set InfluxDB v1.X authentication params using values defined in secrets.h.  Not needed as such
-    // for InfluxDB v2.X (which uses a token-based scheme via the constructor).
-    dbclient.setConnectionParamsV1(INFLUXDB_URL, INFLUXDB_DB_NAME, INFLUXDB_USER, INFLUXDB_PASSWORD);
+  // InfluxDB client instance for InfluxDB 1
+  InfluxDBClient dbclient(INFLUXDB_URL, INFLUXDB_DB_NAME);
   #endif
-  
-  // Add constant Influx data point tags - only do once, will be added to all individual data points
-  // Modify if required to reflect your InfluxDB data model (and set values in config.h)
-  // First for environmental data
-  dbenvdata.addTag("device", DEVICE_TYPE);
-  dbenvdata.addTag("location", DEVICE_LOCATION);
-  dbenvdata.addTag("site", DEVICE_SITE);
-  // And again for device data
-  dbdevdata.addTag("device", DEVICE_TYPE);
-  dbdevdata.addTag("location", DEVICE_LOCATION);
-  dbdevdata.addTag("site", DEVICE_SITE);
 
-  // If confirmed connection to InfluxDB server, store our data values (with retries)
-  boolean dbsuccess = false;
-  int dbtries;
-  for (dbtries = 1; dbtries <= CONNECT_ATTEMPT_LIMIT; dbtries++) {
-    debugMessage(String("InfluxDB connection attempt ") + dbtries + " of "+ CONNECT_ATTEMPT_LIMIT + " in " + String(CONNECT_ATTEMPT_INTERVAL) + " seconds");
-    if (dbclient.validateConnection()) {
-      debugMessage("Connected to InfluxDB: " + dbclient.getServerUrl());
-      dbsuccess = true;
-      break;
-    }
-    delay(CONNECT_ATTEMPT_INTERVAL*1000);
-  }
-  if(dbsuccess == false) {
-    debugMessage("InfluxDB connection failed: " + dbclient.getLastErrorMessage());
-    return(false);
-  }
-  else 
+  #ifdef INFLUX_V2
+  // InfluxDB client instance for InfluxDB 2
+  InfluxDBClient dbclient(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN);
+  #endif
+
+  // InfluxDB Data point, binds to InfluxDB 'measurement' to use for data. See config.h for value used
+  Point dbenvdata(INFLUX_ENV_MEASUREMENT);
+  Point dbdevdata(INFLUX_DEV_MEASUREMENT);
+
+  // Post data to Influx DB using the connection established during setup
+  boolean post_influx(float pm25, float aqi, int rssi)
   {
-    // Connected, so store sensor values into timeseries data point
-    dbenvdata.clearFields();
-    // Report sensor readings
-    dbenvdata.addField("temperature", tempF);
-    dbenvdata.addField("humidity", humidity);
-    dbenvdata.addField("co2", co2);
-    debugMessage("Writing: " + dbclient.pointToLineProtocol(dbenvdata));
-    // Write point via connection to InfluxDB host
-    if (!dbclient.writePoint(dbenvdata)) {
-      debugMessage("InfluxDB write failed: " + dbclient.getLastErrorMessage());
-      dbsuccess = false;  // So close...
-    }
+    Serial.println("Saving data to Influx");
+    #ifdef INFLUX_V1
+      // Set InfluxDB v1.X authentication params using values defined in secrets.h.  Not needed as such
+      // for InfluxDB v2.X (which uses a token-based scheme via the constructor).
+      dbclient.setConnectionParamsV1(INFLUXDB_URL, INFLUXDB_DB_NAME, INFLUXDB_USER, INFLUXDB_PASSWORD);
+    #endif
+    
+    // Add constant Influx data point tags - only do once, will be added to all individual data points
+    // Modify if required to reflect your InfluxDB data model (and set values in config.h)
+    // First for environmental data
+    dbenvdata.addTag("device", DEVICE_TYPE);
+    dbenvdata.addTag("location", DEVICE_LOCATION);
+    dbenvdata.addTag("site", DEVICE_SITE);
+    // And again for device data
+    dbdevdata.addTag("device", DEVICE_TYPE);
+    dbdevdata.addTag("location", DEVICE_LOCATION);
+    dbdevdata.addTag("site", DEVICE_SITE);
 
-    // Now store device information 
-    dbdevdata.clearFields();
-    // Report device readings
-    if (batteryVoltageAvailable)
-      dbdevdata.addField("battery_volts", battery_v);
-    if (internetAvailable)
-      dbdevdata.addField("rssi", rssi);
-    if ((batteryVoltageAvailable) || (internetAvailable))
+    // If confirmed connection to InfluxDB server, store our data values (with retries)
+    boolean dbsuccess = false;
+    int dbtries;
+    for (dbtries = 1; dbtries <= CONNECT_ATTEMPT_LIMIT; dbtries++) {
+      debugMessage(String("InfluxDB connection attempt ") + dbtries + " of "+ CONNECT_ATTEMPT_LIMIT + " in " + String(CONNECT_ATTEMPT_INTERVAL) + " seconds");
+      if (dbclient.validateConnection()) {
+        debugMessage("Connected to InfluxDB: " + dbclient.getServerUrl());
+        dbsuccess = true;
+        break;
+      }
+      delay(CONNECT_ATTEMPT_INTERVAL*1000);
+    }
+    if(dbsuccess == false) {
+      debugMessage("InfluxDB connection failed: " + dbclient.getLastErrorMessage());
+      return(false);
+    }
+    else 
     {
+      // Connected, so store sensor values into timeseries data point
+      dbenvdata.clearFields();
+      // Report sensor readings
+      dbenvdata.addField("pm25", pm25);
+      dbenvdata.addField("aqi", aqi);
+      debugMessage("Writing: " + dbclient.pointToLineProtocol(dbenvdata));
       // Write point via connection to InfluxDB host
-      debugMessage("Writing: " + dbclient.pointToLineProtocol(dbdevdata));
-      if (!dbclient.writePoint(dbdevdata))
-      {
+      if (!dbclient.writePoint(dbenvdata)) {
         debugMessage("InfluxDB write failed: " + dbclient.getLastErrorMessage());
         dbsuccess = false;  // So close...
       }
+
+      // Now store device information 
+      dbdevdata.clearFields();
+      // Report device readings
+      if (internetAvailable)
+      {
+        dbdevdata.addField("rssi", rssi);
+        // Write point via connection to InfluxDB host
+        debugMessage("Writing: " + dbclient.pointToLineProtocol(dbdevdata));
+        if (!dbclient.writePoint(dbdevdata))
+        {
+          debugMessage("InfluxDB write failed: " + dbclient.getLastErrorMessage());
+          dbsuccess = false;  // So close...
+        }
+      }
+      dbclient.flushBuffer();  // Clear pending writes (before going to sleep)
     }
-    dbclient.flushBuffer();  // Clear pending writes (before going to sleep)
+    return(dbsuccess);
   }
-  return(dbsuccess);
-}
 #endif

--- a/post_mqtt.cpp
+++ b/post_mqtt.cpp
@@ -1,0 +1,162 @@
+// this is a stub to add MQTT publish support to PM2.5
+// code comes from Air Quality project
+// this code has not been updated or tested
+
+#ifdef MQTT
+#include "Arduino.h"
+
+// hardware and internet configuration parameters
+#include "config.h"
+// private credentials for network, MQTT, weather provider
+#include "secrets.h"
+
+#include "aq_network.h"
+extern AQ_Network aq_network;
+
+// Shared helper function
+extern void debugMessage(String messageText);
+
+// Status variables shared across various functions
+extern bool batteryVoltageAvailable;
+extern bool internetAvailable;
+
+  // MQTT setup
+  #include <Adafruit_MQTT.h>
+  #include <Adafruit_MQTT_Client.h>
+  extern Adafruit_MQTT_Client aq_mqtt;
+
+  void mqttConnect()
+  // Connects and reconnects to MQTT broker, call as needed to maintain connection
+  {
+    int8_t mqttErr;
+    int8_t tries;
+  
+    // exit if already connected
+    if (aq_mqtt.connected())
+    {
+      debugMessage(String("Already connected to MQTT broker ") + MQTT_BROKER);
+      return;
+    }
+    for(tries =1; tries <= CONNECT_ATTEMPT_LIMIT; tries++)
+    {
+      debugMessage(String(MQTT_BROKER) + " connect attempt " + tries + " of " + CONNECT_ATTEMPT_LIMIT);
+      if ((mqttErr = aq_mqtt.connect()) == 0)
+      {
+        debugMessage("Connected to MQTT broker");
+        return;
+      }
+      else
+      {
+        // generic MQTT error
+        debugMessage(aq_mqtt.connectErrorString(mqttErr));
+  
+        // Adafruit IO connect errors
+        // switch (mqttErr)
+        // {
+        //   case 1: debugMessage("Adafruit MQTT: Wrong protocol"); break;
+        //   case 2: debugMessage("Adafruit MQTT: ID rejected"); break;
+        //   case 3: debugMessage("Adafruit MQTT: Server unavailable"); break;
+        //   case 4: debugMessage("Adafruit MQTT: Incorrect user or password"); break;
+        //   case 5: debugMessage("Adafruit MQTT: Not authorized"); break;
+        //   case 6: debugMessage("Adafruit MQTT: Failed to subscribe"); break;
+        //   default: debugMessage("Adafruit MQTT: GENERIC - Connection failed"); break;
+        // }
+        aq_mqtt.disconnect();
+        debugMessage(String("Attempt failed, trying again in ") + CONNECT_ATTEMPT_INTERVAL + " seconds");
+        delay(CONNECT_ATTEMPT_INTERVAL*1000);
+      }
+    }
+    debugMessage(String("Connection failed to MQTT broker: ") + MQTT_BROKER);
+  } 
+
+  int mqttDeviceBatteryUpdate(float cellVoltage)
+  {
+    int result = 0;
+    if (batteryVoltageAvailable)
+    {
+      //Adafruit_MQTT_Publish batteryVoltagePub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC5, MQTT_QOS_1); // if problematic, remove QOS parameter
+      Adafruit_MQTT_Publish batteryVoltagePub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC5);
+      mqttConnect();
+
+      // publish battery voltage
+      if (batteryVoltagePub.publish(cellVoltage))
+      {
+        debugMessage("MQTT publish: Battery Voltage succeeded");
+        result = 1;
+      }
+      else
+      {
+        debugMessage("MQTT publish: Battery Percent failed");
+      }
+      aq_mqtt.disconnect(); 
+    }
+    return(result);
+  }
+
+  int mqttDeviceWiFiUpdate(int rssi)
+  {
+    int result = 0;
+    if (internetAvailable)
+    {
+      // Adafruit_MQTT_Publish rssiLevelPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC6, MQTT_QOS_1); // if problematic, remove QOS parameter
+      Adafruit_MQTT_Publish rssiLevelPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC6);
+      mqttConnect();
+
+      if (rssiLevelPub.publish(rssi))
+      {
+        debugMessage("MQTT publish: WiFi RSSI succeeded");
+        result = 1;
+      }
+      else
+      {
+        debugMessage("MQTT publish: WiFi RSSI failed");
+      }
+      aq_mqtt.disconnect();
+    }
+    return(result);
+  }
+  
+  int mqttSensorUpdate(uint16_t co2, float tempF, float humidity)
+  // Publishes sensor data to MQTT broker
+  {
+    // Adafruit_MQTT_Publish tempPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC1, MQTT_QOS_1); // if problematic, remove QOS parameter
+    // Adafruit_MQTT_Publish humidityPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC2, MQTT_QOS_1);
+    // Adafruit_MQTT_Publish co2Pub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC3, MQTT_QOS_1);
+    Adafruit_MQTT_Publish tempPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC1);
+    Adafruit_MQTT_Publish humidityPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC2);
+    Adafruit_MQTT_Publish co2Pub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC3);   
+    int result = 1;
+    
+    mqttConnect();
+    // Attempt to publish sensor data
+    if(tempPub.publish(tempF))
+    {
+      debugMessage("MQTT publish: Temperature succeeded");
+    }
+    else {
+      debugMessage("MQTT publish: Temperature failed");
+      result = 0;
+    }
+    
+    if(humidityPub.publish(humidity))
+    {
+      debugMessage("MQTT publish: Humidity succeeded");
+    }
+    else {
+      debugMessage("MQTT publish: Humidity failed");
+      result = 0;
+    }
+    
+    if(co2Pub.publish(co2))
+    {
+      debugMessage("MQTT publish: CO2 succeeded");
+    }
+    else
+    {
+      debugMessage("MQTT publish: CO2 failed");
+      result = 0;
+    }
+    aq_mqtt.disconnect();
+    return(result);
+  }
+#endif

--- a/post_thingspeak.cpp
+++ b/post_thingspeak.cpp
@@ -1,0 +1,49 @@
+// ThingSpeak data upload
+// this code has not been updated or tested
+
+#ifdef THINGSPEAK
+  const char* ts_server = "api.thingspeak.com";
+  void post_thingspeak(float pm25, float minaqi, float maxaqi, float aqi) {
+    if (client.connect(ts_server, 80)) {
+      
+      // Measure Signal Strength (RSSI) of Wi-Fi connection
+      long rssi = WiFi.RSSI();
+      Serial.print("RSSI: ");
+      Serial.println(rssi);
+
+      // Construct API request body
+      String body = "field1=";
+             body += String(aqi,2);
+             body += "&";
+             body += "field2=";
+             body += String(pm25,2);
+             body += "&";
+             body += "field3=";
+             body += String(maxaqi,2);
+             body += "&";
+             body += "field4=";
+             body += String(minaqi,2);
+
+
+      client.println("POST /update HTTP/1.1");
+      client.println("Host: api.thingspeak.com");
+      client.println("User-Agent: ESP8266 (orangemoose)/1.0");
+      client.println("Connection: close");
+      client.println("X-THINGSPEAKAPIKEY: " + String(THINGS_APIKEY));
+      client.println("Content-Type: application/x-www-form-urlencoded");
+      client.println("Content-Length: " + String(body.length()));
+      client.println("");
+      client.print(body);
+      Serial.println(body);
+
+    }
+    delay(1500);
+      
+    // Read all the lines of the reply from server (if any) and print them to Serial Monitor
+    while(client.available()){
+      String line = client.readStringUntil('\r');
+      Serial.print(line);
+    }
+    client.stop();
+  }
+#endif

--- a/secrets_template.h
+++ b/secrets_template.h
@@ -1,27 +1,27 @@
 // Copy this file to "secrets.h" and adjust the access credentials here to
 // match your deployment environment.
 
-// WiFi configuration settings
-#define WIFI_SSID "YOUR_WIFI_SSID"
-#define WIFI_PASS "YOUR_WIFI_PASSWORD"
+// // WiFi configuration settings
+// #define WIFI_SSID "YOUR_WIFI_SSID"
+// #define WIFI_PASS "YOUR_WIFI_PASSWORD"
 
-// Device configuration info for dweet.io & ThingSpeak
-/* Info for home cellar monitor */
-#define DWEET_DEVICE "UNIQUE_DWEET_DEVICE_NAME"
-#define THINGS_CHANID 9999999           // ThingSpeak channel ID
-#define THINGS_APIKEY "CHANNEL_WRITE_APIKEY"// write API key for ThingSpeak Channel
+// // Device configuration info for dweet.io & ThingSpeak
+// /* Info for home cellar monitor */
+// #define DWEET_DEVICE "UNIQUE_DWEET_DEVICE_NAME"
+// #define THINGS_CHANID 9999999           // ThingSpeak channel ID
+// #define THINGS_APIKEY "CHANNEL_WRITE_APIKEY"// write API key for ThingSpeak Channel
 
-// InfluxDB server url using name or IP address (not localhost)
-#define INFLUXDB_URL "http://influxdbhost.local:8086"
-// InfluxDB v1 database name 
-#define INFLUXDB_DB_NAME "home"
-// InfluxDB v1 user name
-#define INFLUXDB_USER "GRAFANA_USER"
-// InfluxDB v1 user password
-#define INFLUXDB_PASSWORD "GRAFANA_PASSWORD"
+// // InfluxDB server url using name or IP address (not localhost)
+// #define INFLUXDB_URL "http://influxdbhost.local:8086"
+// // InfluxDB v1 database name 
+// #define INFLUXDB_DB_NAME "home"
+// // InfluxDB v1 user name
+// #define INFLUXDB_USER "GRAFANA_USER"
+// // InfluxDB v1 user password
+// #define INFLUXDB_PASSWORD "GRAFANA_PASSWORD"
 
-// Tags values for InfluxDB data points.  Should be customized to match your 
-// InfluxDB data model, and can add more here and in post_influx.cpp if desired
-#define DEVICE_NAME "aqi_pm25"
-#define DEVICE_LOCATION "backyard"
-#define DEVICE_SITE "outdoor"
+// // Tags values for InfluxDB data points.  Should be customized to match your 
+// // InfluxDB data model, and can add more here and in post_influx.cpp if desired
+// #define DEVICE_NAME "aqi_pm25"
+// #define DEVICE_LOCATION "backyard"
+// #define DEVICE_SITE "outdoor"


### PR DESCRIPTION
This version extends support for multiple data endpoints. It uses config.h and secrets.h to configure data capture and endpoint connections. This code has endpoint support for MQTT brokers and influxDB, both of which have been tested. It has code stubs for DWEET and ThingSpeak endpoints, but that code is not complete or tested.

This branch also has other code modifications, but nothing that changes the core data capture capabilities previously included.