### PR TITLE
Enhanced support for back-end services

### DIFF
--- a/Feather_AQI_Monitor_SEN54.ino
+++ b/Feather_AQI_Monitor_SEN54.ino
@@ -11,19 +11,11 @@
 #include "config.h"
 #include "secrets.h"
 
-// ESP32 WiFi
-#include <WiFi.h>
-
-//ESP8266 WiFi
-//#include <ESP8266WiFi.h>
-
 // Use WiFiClient class to create TCP connections and talk to hosts
 WiFiClient client;
 
 //Create SEN5x sensor instance
 SensirionI2CSen5x sen5x;
-//Simulate sensor operations, e.g. for testing
-#define SIMULATE_SENSOR
 
 // global variables
 
@@ -68,7 +60,7 @@ int rssi;
 #endif
 
 #ifdef THINGSPEAK
-  extern void post_thingspeak(avgPM25,pm25toAQI(MinPm25),pm25toAQI(MaxPm25),pm25toAQI(avgPM25));
+  extern void post_thingspeak(float pm25, float minaqi, float maxaqi, float aqi);
 #endif
 
 #ifdef INFLUX
@@ -89,21 +81,21 @@ int rssi;
 
 void setup() 
 {
-  // handle Serial first so debugMessage() works
-  #ifdef DEBUG
-    Serial.begin(115200);
-    // wait for serial port connection
-    while (!Serial);
+  // handle Serial first so status messages and debugMessage() work
+  Serial.begin(115200);
+  // wait for serial port connection
+  // while (!Serial);  // FIX: Infinite loop if no serial connection
+  delay(5000);   // Workaround to give Serial port a chance to open
+  
+  // Enable LED for visual confirmation of reporting (and turn it off)
+  pinMode(LED_BUILTIN,OUTPUT);
+  digitalWrite(LED_BUILTIN, LED_BUILTIN_OFF);    // turn the LED
 
-    // Enable LED for visual confirmation of reporting
-    pinMode(LED_BUILTIN,OUTPUT);
-
-    // Display key configuration parameters
-    debugMessage("PM2.5 monitor started");
-    debugMessage(String("Sample interval is ") + SAMPLE_INTERVAL + " seconds");
-    debugMessage(String("Report interval is ") + REPORT_INTERVAL + " minutes");
-    debugMessage(String("Internet service reconnect delay is ") + CONNECT_ATTEMPT_INTERVAL + " seconds");
-  #endif
+  // Display key configuration parameters
+  Serial.println("PM2.5 monitor started");
+  Serial.println(String("Sample interval is ") + SAMPLE_INTERVAL + " seconds");
+  Serial.println(String("Report interval is ") + REPORT_INTERVAL + " minutes");
+  Serial.println(String("Internet service reconnect delay is ") + CONNECT_ATTEMPT_INTERVAL + " seconds");
 
   // handle error condition
   initSensor();
@@ -111,8 +103,11 @@ void setup()
   // Remember current clock time
   prevReportMs = prevSampleMs = millis();
 
-  if(networkConnect())
+  if(networkConnect()) {
     internetAvailable = true;
+  }
+
+  debugMessage("----- Sampling -----");
 }
 
 void loop()
@@ -135,15 +130,16 @@ void loop()
       humidityTotal += sensorData.ambientHumidity;
       vocTotal += sensorData.vocIndex;
 
-      debugMessage(String("PM2.5 reading is ") + sensorData.massConcentrationPm2p5 + " or AQI " + pm25toAQI(sensorData.massConcentrationPm2p5));
-      debugMessage(String("Temp is ") + sensorData.ambientTemperature + " F");
-      debugMessage(String("Humidity is ") + sensorData.ambientHumidity + "%");
-      debugMessage(String("VOC level is ") + sensorData.vocIndex);
-      debugMessage(String("Sample count is ") + numSamples);
-      debugMessage(String("Running PM25 total for this sample period is ") + pm25Total);
-      debugMessage(String("Running tempF total for this sample period is ") + tempFTotal);
-      debugMessage(String("Running humidity total for this sample period is ") + humidityTotal);
-      debugMessage(String("Running VOC index total for this sample period is ") + vocTotal);
+      Serial.print("Current Readings: ");
+      Serial.print(String("PM2.5: ") + sensorData.massConcentrationPm2p5 + " = AQI " + pm25toAQI(sensorData.massConcentrationPm2p5));
+      Serial.print(String(", Temp: ") + sensorData.ambientTemperature + " F");
+      Serial.print(String(", Humidity:  ") + sensorData.ambientHumidity + "%");
+      Serial.println(String(", VOC: ") + sensorData.vocIndex);
+      debugText(String("Sample #") + numSamples + String(", running totals: "),false);
+      debugText(String("PM25 total: ") + pm25Total,false);
+      debugText(String(", TempF total: ") + tempFTotal,false);
+      debugText(String(", Humidity total: ") + humidityTotal,false);
+      debugText(String(", VOC total: ") + vocTotal,true);
 
       // Save sample time
       prevSampleMs = currentMillis;
@@ -167,10 +163,13 @@ void loop()
       avgVOC = vocTotal / numSamples;
       avgHumidity = humidityTotal / numSamples;
 
-      debugMessage(String("Average PM2.5 reading for this ") + REPORT_INTERVAL + " minute report interval  is " + avgPM25 + " or AQI " + pm25toAQI(avgPM25));
-      debugMessage(String("Average temp reading for this ") + REPORT_INTERVAL + " minute report interval  is " + avgTempF);
-      debugMessage(String("Average humidity reading for this ") + REPORT_INTERVAL + " minute report interval  is " + avgHumidity);
-      debugMessage(String("Average VoC reading for this ") + REPORT_INTERVAL + " minute report interval  is " + avgVOC);
+      Serial.println("----- Reporting -----");
+      Serial.print(String("Reporting averages (") + REPORT_INTERVAL + String(" minute): "));
+
+      Serial.print(String("PM2.5: ") + avgPM25 + String(" = AQI ") + pm25toAQI(avgPM25));
+      Serial.print(String(", Temp: ") + avgTempF + String(" F"));
+      Serial.print(String(", Humidity: ") + avgHumidity + String("%"));
+      Serial.println(String(", VoC: ") + avgVOC);
 
       // reconnect to WiFi if needed
       if (WiFi.status() != WL_CONNECTED){
@@ -178,11 +177,8 @@ void loop()
           WiFi.reconnect();
       }
 
-      // Blink the LED
-      digitalWrite(LED_BUILTIN, HIGH);   // turn the LED on (HIGH is the voltage level)
-      delay(500);                // wait for a half second
-      digitalWrite(LED_BUILTIN, LOW);    // turn the LED off by making the voltage LOW
-      delay(500);
+      // Visual indication we're updating remote/internet services
+      blink_led();
 
       /* Post both the current readings and historical max/min readings to the internet */
       #ifdef DWEET
@@ -206,6 +202,7 @@ void loop()
           debugMessage("Did not write environment data to MQTT broker");
       #endif
 
+      debugMessage("----- Sampling -----");
       // Reset counters and accumulators
       prevReportMs = currentMillis;
       numSamples = 0;
@@ -318,14 +315,14 @@ bool readSensor()
 
   // If we're simulating the sensor generate some reasonable values for measurements
   #ifdef SIMULATE_SENSOR
-    sensorData.massConcentrationPm1p0 = 1.0;
-    sensorData.massConcentrationPm2p5 = 2.5;
-    sensorData.massConcentrationPm4p0 = 4.0;
-    sensorData.massConcentrationPm10p0 = 10.0;
-    sensorData.ambientHumidity = 56.7;
-    sensorData.ambientTemperature = 20.0;
-    sensorData.vocIndex = 27.0;
-    sensorData.noxIndex = 5.0;
+    sensorData.massConcentrationPm1p0 = random(0,360)/10.0;
+    sensorData.massConcentrationPm2p5 = random(0,360)/10.0;
+    sensorData.massConcentrationPm4p0 = random(0,720)/10.0;
+    sensorData.massConcentrationPm10p0 = random(0,1550)/10.0;
+    sensorData.ambientHumidity = 30.0 + (random(0,250)/10.0);
+    sensorData.ambientTemperature = 15.0 + (random(0,101)/10.0);
+    sensorData.vocIndex = random(0,3500)/10.0;
+    sensorData.noxIndex = random(0,2500)/10.0;
     return true;
   #endif
 
@@ -367,4 +364,27 @@ void debugMessage(String messageText)
     Serial.println(messageText);
     Serial.flush();  // Make sure the message gets output (before any sleeping...)
   #endif
+}
+
+// Output debug text to Serial, allows optional newline after the text
+void debugText(String outputText,bool newline)
+{
+  #ifdef DEBUG
+    if(newline) {
+      Serial.println(outputText);
+      Serial.flush();
+    }
+    else {
+      Serial.print(outputText);
+    }
+  #endif
+}
+
+void blink_led()
+{
+      // Blink the LED
+      digitalWrite(LED_BUILTIN, LED_BUILTIN_ON);   // turn the LED on
+      delay(500);                // wait for a half second
+      digitalWrite(LED_BUILTIN, LED_BUILTIN_OFF);    // turn the LED
+      delay(500);
 }

--- a/README.md
+++ b/README.md
@@ -1,17 +1,66 @@
 # PM2.5 Air Quality Monitor
 
-This project is an update to my earlier PM2.5 Air Quality Monitor.  The previous version used an older [Plantower PM2.5 air quality sensor](https://www.adafruit.com/product/3686) sensor that did a fine job measuring 2.5 micron particulates and helping me keep an eye on overall air quality at our home, but used a serial UART interface that was a bit tedious to program for.   Earlier this year Sensirion introduced their new [SEN5x](https://sensirion.com/products/catalog/SEN54/) air quality sensors with a much easier to manage I2C interface.  Sparkfun sells the [SEN54](https://www.sparkfun.com/products/19325), which measures PM1.0, PM2.5, and PM10.0 particulates as well as Volatile Organic Compounds (VOC), temperature and humidity.  Delightfully, Sensirion provides [Arduino libraries](https://github.com/Sensirion/arduino-i2c-sen5x) for the SEN5x series, making it an ideal upgrade for my home air quality monitor.
+## Project Overview
 
-The [Adafruit Feather Huzzah](https://www.adafruit.com/product/2821) continues to be a great microcontroller option for projects like this given the built-in WiFi support, flexible power options, ready access to GPIO, and Feather form factor.
+This project is now in its third generation, having evolved from an intial form that used
+an older Plantower PM2.5 air quality sensor](https://www.adafruit.com/product/3686) sensor, which did
+a fine job measuring 2.5 micron particulates and allowing monitoring of overall air quality but
+used a serial UART interface that was a bit tedious to program for. The second generation switched
+to a newer sensor from the Sensirion SEN5x series, specifically an
+[SEN54](https://sensirion.com/products/catalog/SEN54/), offering measurement of a wider range of
+environmental values plus built-in I2C communications. Sparkfun sells the
+[SEN54](https://www.sparkfun.com/products/19325), which measures PM1.0, PM2.5, and PM10.0
+particulates as well as Volatile Organic Compounds (VOC), temperature and humidity. Delightfully,
+Sensirion provides [Arduino libraries](https://github.com/Sensirion/arduino-i2c-sen5x) for the
+SEN5x series, along with some excellent example sketches.
 
-In addition to preserving support of [Dweet](https://dweet.io) and [ThingSpeak](https://thingspeak.com) for reporting data, I added support for storing data locally using InfluxDB.  I have InfluxDB 1.8 running on a Raspberry Pi 4 on my home network, using it to add local data storage capabilities to many of my smart home and IoT projects.  As a time series database it's perfect for sensor and device event storage, and built-in integration with Grafana enables quick construction of powerful browser-based graphical dashboards that look great on computer, tablet, and mobile phone.
+The [Adafruit Feather Huzzah](https://www.adafruit.com/product/2821) continues to be a great
+microcontroller option for projects like this given the onboard ESP8266 with built-in WiFi support, 
+flexible power options, ready access to GPIO, and Feather form factor.  Newer Feather devices
+are built on the more powerful ESP32 and are supported here as well.
 
-Much of the rest of the project remains the same as the previous version, especially the code that calculates AQI values from particulate readings using a [complex but obscure formula](https://forum.airnowtech.org/t/the-aqi-equation/169) that continues to not be part of anyone's AQI sensor libraries, alas.
+Over time the code here has evolved to add an increasing range of back-end data publishing and
+reporting services, including [Dweet](https://dweet.io), [ThingSpeak](https://thingspeak.com),
+[InfluxDB](https://www.influxdata.com), [MQTT](https://io.adafruit.com/api/docs/mqtt.html), and
+[Home Assistant](https://www.home-assistant.io) via MQTT. This makes it easy to access AQI
+data from the sensor in web pages, on mobile devices, through graphing facilities like
+[Grafana](https://grafana.com/), and even in automating smart home system responses to good or
+bad overall air. Services supported are configurable through compile-time settings and via
+separate routines for posting data as appropriate.
 
-After our experience with alarmingly poor air quality during the California wildfire outbreak in the summer of 2020 I'm very mindful of keeping an eye on particulate levels in the air both inside and outside our home.  The SEN54 plus Feather MCU with InfluxDB and Grafana gives me all the tools I need to do that.
+## What is AQI Anyway?
+It's worth noting that while most people have heard of an "Air Quality Index" from their local
+weather service or news, the calculation of AQI from sensor readings is less well known.  Sensors
+like the Sensirion SEN54 measure and report particulate concentrations in various size ranges, the
+most widely used of which is "PM2.5", meaning airborne particulates of 2.5 microns in diameter or
+smaller, measured in micrograms per cubic meter.  The more particulates measured the worse the air
+quality and, eventually, the greater the danger to humans and animals.  Howeveer, the perceived
+quality of the air and the risk from exposure vary in a non-obvious way based on the actual PM2.5
+values observed.  That variability is what gave rise to the idea of an Air Quality Index in the
+first place, though as is often the case in associating health factors and risk with environmental
+data different governing bodies and standards organizations have put forward different ways of
+calculating risk from sensor data.  You can read much more about this in the Wikipedia page for
+Air Quality, which you'll find [here](https://en.wikipedia.org/wiki/Air_quality_index).
+
+In the US, the Environmental Protection Agency (EPA) developed its own AQI measure, dividing the
+normal range of measured particulates and pollutants into six categories indicating increased 
+levels of health concerns.  An overall AQI value is calculated from a piecewise linear function,
+with scaling and transition points defined by the EPA.  More details on that math are shared in the
+Wikipedia page cited above, as well as this [post](https://forum.airnowtech.org/t/the-aqi-equation/169)
+on the AirNow tech forum.  Code included in this project handles calculating US EPA AQI from
+PM2.5 readings returned by the SEN54 sensor (which curiously is not a feature built into the
+SEN5x Arduino library though probalby should be).
 
 ## Usage Notes
 
-Important access settings like WiFi SSID and password, ThingSpeak keys, and InfluxDB credentials are contained in a `secrets.h` file that is not included in this repo.  Instead you'll find the file `secrets_template.h`, which should be copied to `secrets.h` and then edited to supply the right access credentials and configuration values to match your deployment environment.
+Important access settings like WiFi SSID and password, ThingSpeak keys, and InfluxDB credentials
+are contained in a `secrets.h` file that is not included in this repo.  Instead you'll find the
+file `secrets_template.h`, which should be copied to `secrets.h` and then edited to supply the
+right access credentials and configuration values to match your deployment environment.
 
-I've written general purpose functions to do data reporting via Dweet, ThingSpeak, and InfluxDB and use them consistently across my Feather Huzzah and ESP32 projects.  In their current form they need to be customized per project to transmit the right data fields depending on what the project is trying to report.  They also require some configuration of the connections to Dweet (in the form of the device name), ThingSpeak (in the form of channel ID number and API write key), and InfluxDB (to specify the server and login account for data logging along with the measurement schema for storing data).  You'll need to edit the project code to use whatever configuration values are appropriate for you.
+The routines that post data to back end services are generalized as much as practical, though do
+need to be customized to match the data fieles of interest both within the scope of the project
+and based on what users want to report and monitor.  Configuration values in config.h help with
+basic customization, e.g. name of the device, tags to use for Influx data, though in some cases
+code may need to be modified in the associated post routine.
+

--- a/config.h
+++ b/config.h
@@ -5,21 +5,47 @@
   See README.md for target information and revision history
 */
 
+// Choose the right WiFi package, either ESP32 or ESP8266.  Provides access
+// to the WiFiClient object class and accessor.  May not be needed for all
+// network service access where service-specific libraries encapsulate it.
+
+// ESP32 WiFi
+//#include <WiFi.h>
+
+// ESP8266 WiFi
+#include <ESP8266WiFi.h>
+
+// When is the onboard LED (LED_BUILTIN) on?  
+#define LED_BUILTIN_ON    LOW
+#define LED_BUILTIN_OFF   HIGH
+
 // Step 1: Set conditional compile flags
 #define DEBUG     // Output to serial port
 #define MQTT        // log sensor data to MQTT broker
+//#define HASSIO_MQTT  // And, if MQTT enabled, with Home Assistant too?
 #define INFLUX      // Log data to InfluxDB server
 // #define DWEET       // Log data to Dweet service
 // #define THINGSPEAK  // Log data to ThingSpeak
 
+// Simulate SEN5x sensor operations, e.g. for testing or easier development.  Returns random
+// but plausible values for sensor readings.
+//#define SIMULATE_SENSOR
+
+// Sensor(s) are sampled at one interval, generally fairly often.  Readings
+// are averaged and reported at a longer interval.  Configure that behavior here,
+// allowing for more frequent processing when in DEBUG mode.
 #ifdef DEBUG
-  const int SAMPLE_INTERVAL = 5;  // sample interval for sensor in seconds
-  const int REPORT_INTERVAL = 1; // Interval at which samples are averaged & reported in minutes)
+  #define SAMPLE_INTERVAL 5   // sample interval for sensor in seconds
+  #define REPORT_INTERVAL 1   // Interval at which samples are averaged & reported in minutes)
 #else
-  const int SAMPLE_INTERVAL = 30;  // sample interval for sensor in seconds
-  const int REPORT_INTERVAL = 15; // Interval at which samples are averaged & reported in minutes)
+  #define SAMPLE_INTERVAL 30  // sample interval for sensor in seconds
+  #define REPORT_INTERVAL 15 // Interval at which samples are averaged & reported in minutes)
 #endif
 
+// To allow for varying network singal strength and responsiveness, make multiple
+// attempts to connect to internet services at a measured interval.  If your environment
+// is more challenged you may want to allow for more connection attempts and/or a longer
+// delay between connection attempts.
 const int CONNECT_ATTEMPT_LIMIT = 3;      // max connection attempts to internet services
 const int CONNECT_ATTEMPT_INTERVAL = 5;  // seconds between internet service connect attempts
 
@@ -27,38 +53,54 @@ const int CONNECT_ATTEMPT_INTERVAL = 5;  // seconds between internet service con
 #define CLIENT_ID "PM25"
 
 #ifdef MQTT
-  // Adafruit I/O
-  // structure: username/feeds/groupname.feedname or username/feeds/feedname
-  // e.g. #define MQTT_PUB_TEMPF   "sircoolio/feeds/pocket-office.tempf"
+  // Define MQTT topics used to publish sensor readings and device attributes.
+  // Representative structure: username/feeds/groupname/feedname or username/feeds/feedname
+  // e.g. #define MQTT_PUB_TEMPF   "sircoolio/feeds/office/tempf"
 
-  // structure: site/room/device/data 
+  // Default structure: site/room/device/data 
   #define MQTT_PUB_PM25       "7828/demo/pm25/pm25"
   #define MQTT_PUB_AQI        "7828/demo/pm25/aqi"
   #define MQTT_PUB_TEMPF      "7828/demo/pm25/tempf"
   #define MQTT_PUB_VOC        "7828/demo/pm25/vocindex"
   #define MQTT_PUB_HUMIDITY   "7828/demo/pm25/humidity"
   #define MQTT_PUB_RSSI       "7828/demo/pm25/rssi"
+
+  // Additional state topic if integrating with Home Assistant
+  #ifdef HASSIO_MQTT
+    // Home Assistant integration wants all reported values published in one JSON
+    // payload to a single "state" topic. See Home Assistant documentation for more details.
+    // NOTE: MUST MATCH value used in Home Assistant MQTT configuration file 
+    // (configuration.yaml). See hassio_mqtt.cpp for details.
+    #define MQTT_HASSIO_STATE   "homeassistant/sensor/aqi-1/state"
+  #endif
 #endif
 
 #ifdef INFLUX  
   // Name of Measurements expected/used in the Influx DB.
   #define INFLUX_ENV_MEASUREMENT "weather"  // Used for environmental sensor data
-  #define INFLUX_DEV_MEASUREMENT "device"   // Used for logging AQI device data (e.g. battery)
+  #define INFLUX_DEV_MEASUREMENT "device"   // Used for logging device data (e.g. battery)
   
   // Standard set of tag values used for each sensor data point stored to InfluxDB.  Reuses
   // CLIENT_ID as defined anove here in config.h as well as device location (e.g., room in 
   // the house) and site (indoors vs. outdoors, typically).
 
-  #define DEVICE_LOCATION "PM25-test"
-  // #define DEVICE_LOCATION "PM25-demo"
-  //#define DEVICE_LOCATION "kitchen"
-  // #define DEVICE_LOCATION "cellar"
-  // #define DEVICE_LOCATION "lab-office"
-  // #define DEVICE_LOCATION "master bedroom"
-  // #define DEVICE_LOCATION "pocket-office"
 
-  #define DEVICE_SITE "indoor"
+  // Tag data reported to InfluxDB to facilitate retrieval by query later
+  // NAME for this device, should be unique
+  #define DEVICE_NAME "pm25-test"
+
+  // TYPE conveys the kind or class of device.  A location may have multiple devices of a
+  // particular type, so name would be unique but type would not.
   #define DEVICE_TYPE "pm25"
+
+  // Where is the device located?  Generally would the name of a room in a house or
+  // building, e.g. "kitchen", "cellar", "workshop", etc.
+  #define DEVICE_LOCATION "PM25-test"
+
+  // SITE is typically indoor/outdoor or similar aspect apart from device LOCATION.
+  // Can help group devices in ways that go beyond room/location.
+  #define DEVICE_SITE "indoor"
+
 #endif
 
 // Post data to the internet via dweet.io.  Set DWEET_DEVICE to be a

--- a/hassio_mqtt.cpp
+++ b/hassio_mqtt.cpp
@@ -1,0 +1,81 @@
+/*
+ * Additional routines for use in an MQTT-enabled environment with Home Assistant, allowing
+ * sensor readings to be reported to Home Assistant.   
+ * 
+ * Requires the following addition to configuration.yaml for Home Assistant, with the
+ * state topic declared to match MQTT_HASSIO_STATE as defined in config.h. Also, Unique IDs, 
+ * which enable additional UI customization features for the sensors in Home Assistant,
+ * can be generated here: https://www.uuidgenerator.net/version1.
+
+   mqtt:
+    sensor:
+     - name: "Temperature"
+      device_class: "temperature"
+      state_topic: "homeassistant/sensor/aqi-1/state"
+      unit_of_measurement: "°F"
+      unique_id: "-- GENERATE A UUID TO USE HERE --"
+      value_template: "{{ value_json.temperature }}"
+    - name: "Humidity"
+      device_class: "humidity"
+      state_topic: "homeassistant/sensor/aqi-1/state"
+      unit_of_measurement: "%"
+      unique_id: "-- GENERATE A UUID TO USE HERE --"
+      value_template: "{{ value_json.humidity }}"
+    - name: "PM2.5"
+      device_class: "pm25"
+      state_topic: "homeassistant/sensor/aqi-1/state"
+      unit_of_measurement: "µg/m³"
+      unique_id: "-- GENERATE A UUID TO USE HERE --"
+      value_template: "{{ value_json.pm25 }}"
+    - name: "AQI"
+      device_class: "aqi"
+      state_topic: "homeassistant/sensor/aqi-1/state"
+      unit_of_measurement: "AQI"
+      unique_id: "-- GENERATE A UUID TO USE HERE --"
+      value_template: "{{ value_json.aqi }}"
+ */
+
+#include "Arduino.h"
+
+// hardware and internet configuration parameters
+#include "config.h"
+// private credentials for network, MQTT, weather provider
+#include "secrets.h"
+
+// Shared helper function
+extern void debugMessage(String messageText);
+
+#if defined MQTT && defined HASSIO_MQTT
+    // MQTT setup
+    #include <Adafruit_MQTT.h>
+    #include <Adafruit_MQTT_Client.h>
+    #include <ArduinoJson.h>
+    extern Adafruit_MQTT_Client pm25_mqtt;
+
+    // Called to publish sensor readings as a JSON payload, as part of overall MQTT
+    // publishing as implemented in post_mqtt().  Should only be invoked if 
+    // Home Assistant MQTT integration is enabled in config.h.
+    // Note that it depends on the value of the state topic matching what's in Home
+    // Assistant's configuration file (configuration.yaml).
+    void hassio_mqtt_publish(float pm25, float aqi, float tempF, float vocIndex, float humidity) {
+        const int capacity = JSON_OBJECT_SIZE(5);
+        StaticJsonDocument<capacity> doc;
+
+        // Declare buffer to hold serialized object
+        char output[1024];
+        
+        Adafruit_MQTT_Publish rco2StatePub = Adafruit_MQTT_Publish(&pm25_mqtt,MQTT_HASSIO_STATE);
+
+        debugMessage(String("Publishing AQI values to Home Assistant via MQTT, topic: ") + MQTT_HASSIO_STATE);
+        doc["temperature"] = tempF;
+        doc["humidity"] = humidity;
+        doc["aqi"] = aqi;
+        doc["pm25"] = pm25;
+        doc["voc"] = vocIndex;
+
+        serializeJson(doc,output);
+        // Publish state info to its topic (MQTT_HASSIO_STATE)
+        debugMessage(output);
+        rco2StatePub.publish(output);
+    }
+#endif

--- a/post_dweet.cpp
+++ b/post_dweet.cpp
@@ -1,143 +1,84 @@
-// this is a stub to add DWEET publish support to PM2.5
-// code comes from Air Quality project
-// this code has not been updated or tested
+// Port of code from Air Quality, modified for AQI use
+
+#include "Arduino.h"
+
+// hardware and internet configuration parameters
+#include "config.h"
+// private credentials for network, MQTT, weather provider
+#include "secrets.h"
+
+// ESP32 WiFi
+#include <WiFi.h>
+
+//ESP8266 WiFi
+//#include <ESP8266WiFi.h>
 
 // Post a dweet to report sensor data readings.  This routine blocks while
 // talking to the network, so may take a while to execute.
 
 #ifdef DWEET
 
-// David's original PM2.5 dweet code
-const char* dweet_host = "dweet.io";
-void post_dweet(float pm25, float minaqi, float maxaqi, float aqi, float tempF, float vocIndex, float humidity)
-{
-  
-  if(WiFi.status() != WL_CONNECTED) {
-    Serial.print("Lost network connection to '");
-    Serial.print(WIFI_SSID);
-    Serial.println("'!");
-    return;
-  }
-  
-  Serial.print("connecting to ");
-  Serial.print(dweet_host);
-  Serial.print(" as ");
-  Serial.println(String(DWEET_DEVICE));
-      
-  // Use our WiFiClient to connect to dweet
-  if (!client.connect(dweet_host, 80)) {
-    Serial.println("connection failed");
-    return;
-  }
+  // WiFi client object shared with main() routine
+  //extern WiFiClient client;  // (Does this have to be global/shared??)
 
-  long rssi = WiFi.RSSI();
-  IPAddress ip = WiFi.localIP();
-
-  // Use HTTP post and send a data payload as JSON
-  
-  String postdata = "{\"wifi_rssi\":\""     + String(rssi)           + "\"," +
-                     "\"AQI\":\""           + String(aqi,2)          + "\"," +
-                     "\"address\":\""       + ip.toString()          + "\"," +
-                     "\"temperature\":\""   + String(tempF,1)        + "\"," +
-                     "\"vocIndex\":\""      + String(vocIndex,1)     + "\"," +
-                     "\"humidity\":\""      + String(humidity,1)     + "\"," +
-                     "\"PM25_value\":\""    + String(pm25,2)         + "\"," +
-                     "\"min_AQI\":\""       + String(minaqi,2)       + "\"," + 
-                     "\"max_AQI\":\""       + String(maxaqi,2)       + "\"}";
-  // Note that the dweet device 'name' gets set here, is needed to fetch values
-  client.println("POST /dweet/for/" + String(DWEET_DEVICE) + " HTTP/1.1");
-  client.println("Host: dweet.io");
-  client.println("User-Agent: ESP8266 (orangemoose)/1.0");
-  client.println("Cache-Control: no-cache");
-  client.println("Content-Type: application/json");
-  client.print("Content-Length: ");
-  client.println(postdata.length());
-  client.println();
-  client.println(postdata);
-  Serial.println(postdata);
-
-  delay(1500);  
-  // Read all the lines of the reply from server (if any) and print them to Serial Monitor
-  while(client.available()){
-    String line = client.readStringUntil('\r');
-    Serial.print(line);
-  }
-   
-  Serial.println("closing connection");
-  Serial.println();
-}
-
-
-// the post_dweet function from Air Quality, partially modified to send PM 2.5 data
-
-  #include "Arduino.h"
-
-  // hardware and internet configuration parameters
-  #include "config.h"
-
-  #include <HTTPClient.h> 
-
-  // Shared helper functions called from project files
-  extern void debugMessage(String messageText);
-
+  // David's original PM2.5 dweet code
+  const char* dweet_host = "dweet.io";
   void post_dweet(float pm25, float minaqi, float maxaqi, float aqi, float tempF, float vocIndex, float humidity)
   {
-    if(WiFi.status() != WL_CONNECTED)
-    {
-      debugMessage("Lost network connection to '" + String(WIFI_SSID) + "'!");
+    WiFiClient dweet_client;
+
+    if(WiFi.status() != WL_CONNECTED) {
+      Serial.print("Lost network connection to '");
+      Serial.print(WIFI_SSID);
+      Serial.println("'!");
       return;
     }
-    debugMessage("connecting to " + String(DWEET_HOST) + " as " + String(DWEET_DEVICE));
-
-    String dweeturl = "http://" + String(DWEET_HOST) + "/dweet/for/" + String(DWEET_DEVICE);
-
+    
+    Serial.print("connecting to ");
+    Serial.print(dweet_host);
+    Serial.print(" as ");
+    Serial.println(String(DWEET_DEVICE));
+        
     // Use our WiFiClient to connect to dweet
-    if (!client.connect(dweet_host, 80))
-    {
+    if (!dweet_client.connect(dweet_host, 80)) {
       Serial.println("connection failed");
       return;
     }
 
-    // Use HTTP class to publish dweet
-    HTTPClient dweetio;
-    dweetio.begin(client,dweeturl);  
-    dweetio.addHeader("Content-Type", "application/json");
-
+    long rssi = WiFi.RSSI();
+    IPAddress ip = WiFi.localIP();
 
     // Use HTTP post and send a data payload as JSON
-    String device_info = "{\"rssi\":\""   + String(rssi)        + "\"," +
-                         "\"ipaddr\":\"" + WiFi.localIP().toString()  + "\",";
-    String battery_info;
-    if((battpct !=10000)&&(battv != 10000)) {
-      battery_info = "\"battery_percent\":\"" + String(battpct) + "\"," +
-                     "\"battery_voltage\":\"" + String(battv)   + "\",";
-    }
-    else {
-      battery_info = "";
-    }
-
-    String sensor_info;
-    if (co2 !=10000)
-    {
-      sensor_info = "\"co2\":\""         + String(co2)             + "\"," +
-                         "\"temperature\":\"" + String(tempF, 2)         + "\"," +
-                         "\"humidity\":\""    + String(humidity, 2)      + "\"}";
-    }
-    else
-    {
-      sensor_info = "\"temperature\":\"" + String(tempF, 2)         + "\"," +
-                         "\"humidity\":\""    + String(humidity, 2)      + "\"}";
-    }
-
-    String postdata = device_info + battery_info + sensor_info;
-    int httpCode = aq_network.httpPOSTRequest(dweeturl,"application/json",postdata);
     
-    // httpCode will be negative on error, but HTTP status might indicate failure
-    if (httpCode > 0) {
-      // HTTP POST complete, print result code
-      debugMessage("HTTP POST [dweet.io], result code: " + String(httpCode) );
-    } else {
-      debugMessage("HTTP POST [dweet.io] failed, result code: " + String(httpCode));
+    String postdata = "{\"wifi_rssi\":\""     + String(rssi)           + "\"," +
+                      "\"AQI\":\""           + String(aqi,2)          + "\"," +
+                      "\"address\":\""       + ip.toString()          + "\"," +
+                      "\"temperature\":\""   + String(tempF,1)        + "\"," +
+                      "\"vocIndex\":\""      + String(vocIndex,1)     + "\"," +
+                      "\"humidity\":\""      + String(humidity,1)     + "\"," +
+                      "\"PM25_value\":\""    + String(pm25,2)         + "\"," +
+                      "\"min_AQI\":\""       + String(minaqi,2)       + "\"," + 
+                      "\"max_AQI\":\""       + String(maxaqi,2)       + "\"}";
+    // Note that the dweet device 'name' gets set here, is needed to fetch values
+    dweet_client.println("POST /dweet/for/" + String(DWEET_DEVICE) + " HTTP/1.1");
+    dweet_client.println("Host: dweet.io");
+    dweet_client.println("User-Agent: ESP8266 (orangemoose)/1.0");
+    dweet_client.println("Cache-Control: no-cache");
+    dweet_client.println("Content-Type: application/json");
+    dweet_client.print("Content-Length: ");
+    dweet_client.println(postdata.length());
+    dweet_client.println();
+    dweet_client.println(postdata);
+    Serial.println(postdata);
+
+    delay(1500);  
+    // Read all the lines of the reply from server (if any) and print them to Serial Monitor
+    while(dweet_client.available()){
+      String line = dweet_client.readStringUntil('\r');
+      Serial.print(line);
     }
+    
+    Serial.println("closing connection");
+    Serial.println();
   }
 #endif

--- a/post_influx.cpp
+++ b/post_influx.cpp
@@ -59,11 +59,13 @@
       // Add constant Influx data point tags - only do once, will be added to all individual data points
       // Modify if required to reflect your InfluxDB data model (and set values in config.h)
       // First for environmental data
-      dbenvdata.addTag("device", DEVICE_TYPE);
+      dbenvdata.addTag("device", DEVICE_NAME);
+      dbenvdata.addTag("device-type", DEVICE_TYPE);
       dbenvdata.addTag("location", DEVICE_LOCATION);
       dbenvdata.addTag("site", DEVICE_SITE);
       // And again for device data
-      dbdevdata.addTag("device", DEVICE_TYPE);
+      dbdevdata.addTag("device", DEVICE_NAME);
+      dbdevdata.addTag("device-type", DEVICE_TYPE);
       dbdevdata.addTag("location", DEVICE_LOCATION);
       dbdevdata.addTag("site", DEVICE_SITE);
 
@@ -84,9 +86,9 @@
         // Report sensor readings
         dbenvdata.addField("pm25", pm25);
         dbenvdata.addField("aqi", aqi);
-        dbenvdata.addField("tempF", aqi);
-        dbenvdata.addField("vocIndex", aqi);
-        dbenvdata.addField("humidity", aqi);
+        dbenvdata.addField("temperature", tempF);
+        dbenvdata.addField("vocIndex", vocIndex);
+        dbenvdata.addField("humidity", humidity);
         // Write point via connection to InfluxDB host
         if (!dbclient.writePoint(dbenvdata)) {
           debugMessage(String("InfluxDB write failed: ") + dbclient.getLastErrorMessage());

--- a/post_influx.cpp
+++ b/post_influx.cpp
@@ -5,12 +5,12 @@
   See README.md for target information and revision history
 */
 
-  #include "Arduino.h"
+#include "Arduino.h"
 
-  // hardware and internet configuration parameters
-  #include "config.h"
-  // private credentials for network, MQTT, weather provider
-  #include "secrets.h"
+// hardware and internet configuration parameters
+#include "config.h"
+// private credentials for network, MQTT, weather provider
+#include "secrets.h"
 
 // Only compile if InfluxDB enabled
 #ifdef INFLUX

--- a/post_mqtt.cpp
+++ b/post_mqtt.cpp
@@ -109,6 +109,7 @@
       if(pm25Pub.publish(pm25))
       {
         debugMessage("MQTT publish: PM2.5 succeeded");
+        debugMessage(MQTT_PUB_PM25);
         result = true;
       }
       else {

--- a/post_mqtt.cpp
+++ b/post_mqtt.cpp
@@ -18,6 +18,10 @@
   // Shared helper function
   extern void debugMessage(String messageText);
 
+  #ifdef HASSIO_MQTT
+    extern void hassio_mqtt_publish(float pm25, float aqi, float tempF, float vocIndex, float humidity);
+  #endif
+
   // Status variables shared across various functions
   extern bool internetAvailable;
 
@@ -152,6 +156,13 @@
       else {
         debugMessage("MQTT publish: Humidity failed");
       }
+
+      #ifdef HASSIO_MQTT
+        // Either configure sensors in Home Assistant's configuration.yaml file
+        // directly or attempt to do it via MQTT auto-discovery
+        // hassio_mqtt_setup();  // Config for MQTT auto-discovery
+        hassio_mqtt_publish(pm25,aqi,tempF,vocIndex,humidity);
+      #endif
       //pm25_mqtt.disconnect();
     }
     return(result);

--- a/post_thingspeak.cpp
+++ b/post_thingspeak.cpp
@@ -1,15 +1,22 @@
 // ThingSpeak data upload
-// this code has not been updated or tested
+
+#include "Arduino.h"
+
+// hardware and internet configuration parameters
+#include "config.h"
+// private credentials for network, MQTT, weather provider
+#include "secrets.h"
+
 
 #ifdef THINGSPEAK
+  // Shared helper function(s)
+  extern void debugMessage(String messageText);
+
   const char* ts_server = "api.thingspeak.com";
   void post_thingspeak(float pm25, float minaqi, float maxaqi, float aqi) {
-    if (client.connect(ts_server, 80)) {
-      
-      // Measure Signal Strength (RSSI) of Wi-Fi connection
-      long rssi = WiFi.RSSI();
-      Serial.print("RSSI: ");
-      Serial.println(rssi);
+        WiFiClient tspeak_client;
+    
+    if (tspeak_client.connect(ts_server, 80)) {
 
       // Construct API request body
       String body = "field1=";
@@ -25,25 +32,31 @@
              body += String(minaqi,2);
 
 
-      client.println("POST /update HTTP/1.1");
-      client.println("Host: api.thingspeak.com");
-      client.println("User-Agent: ESP8266 (orangemoose)/1.0");
-      client.println("Connection: close");
-      client.println("X-THINGSPEAKAPIKEY: " + String(THINGS_APIKEY));
-      client.println("Content-Type: application/x-www-form-urlencoded");
-      client.println("Content-Length: " + String(body.length()));
-      client.println("");
-      client.print(body);
-      Serial.println(body);
+      tspeak_client.println("POST /update HTTP/1.1");
+      tspeak_client.println("Host: api.thingspeak.com");
+      tspeak_client.println("User-Agent: ESP32/ESP8266 (orangemoose)/1.0");
+      tspeak_client.println("Connection: close");
+      tspeak_client.println("X-THINGSPEAKAPIKEY: " + String(THINGS_APIKEY));
+      tspeak_client.println("Content-Type: application/x-www-form-urlencoded");
+      tspeak_client.println("Content-Length: " + String(body.length()));
+      tspeak_client.println("");
+      tspeak_client.print(body);
+      debugMessage("ThingSpeak POST:");
+      debugMessage(body);
 
     }
     delay(1500);
       
     // Read all the lines of the reply from server (if any) and print them to Serial Monitor
-    while(client.available()){
-      String line = client.readStringUntil('\r');
-      Serial.print(line);
-    }
-    client.stop();
+    #ifdef DEBUG
+      Serial.println("ThingSpeak server response:");
+      while(tspeak_client.available()){
+        String line = tspeak_client.readStringUntil('\r');
+        Serial.print(line);
+      }
+      Serial.println("-----");
+    #endif
+
+    tspeak_client.stop();
   }
 #endif

--- a/secrets_template.h
+++ b/secrets_template.h
@@ -5,6 +5,14 @@
 // #define WIFI_SSID "YOUR_WIFI_SSID"
 // #define WIFI_PASS "YOUR_WIFI_PASSWORD"
 
+// MQTT configuration settings
+// #ifdef MQTT
+//  #define MQTT BROKER    "mqtt.hostname.local or IP address"
+// 	#define MQTT_PORT  			port_number	// use 8883 for SSL
+// 	#define MQTT_USER			 "key_value"
+//  #define MQTT_PASSWORD  "key_value"
+// #endif
+
 // // Device configuration info for dweet.io & ThingSpeak
 // /* Info for home cellar monitor */
 // #define DWEET_DEVICE "UNIQUE_DWEET_DEVICE_NAME"

--- a/secrets_template.h
+++ b/secrets_template.h
@@ -13,23 +13,30 @@
 //  #define MQTT_PASSWORD  "key_value"
 // #endif
 
-// // Device configuration info for dweet.io & ThingSpeak
-// /* Info for home cellar monitor */
-// #define DWEET_DEVICE "UNIQUE_DWEET_DEVICE_NAME"
+// // Device configuration info for ThingSpeak
 // #define THINGS_CHANID 9999999           // ThingSpeak channel ID
 // #define THINGS_APIKEY "CHANNEL_WRITE_APIKEY"// write API key for ThingSpeak Channel
 
-// // InfluxDB server url using name or IP address (not localhost)
+
+// InfluxDB access information, varies depending on whether target server is
+// running v1 or v2 of InfluxDB.  Configure as appropriate.
+
+// If server runs Influx v1.X, configure here
+// InfluxDB server url using name or IP address (not localhost)
 // #define INFLUXDB_URL "http://influxdbhost.local:8086"
-// // InfluxDB v1 database name 
+// InfluxDB v1 database name 
 // #define INFLUXDB_DB_NAME "home"
-// // InfluxDB v1 user name
+// InfluxDB v1 user name
 // #define INFLUXDB_USER "GRAFANA_USER"
-// // InfluxDB v1 user password
+// InfluxDB v1 user password
 // #define INFLUXDB_PASSWORD "GRAFANA_PASSWORD"
 
-// // Tags values for InfluxDB data points.  Should be customized to match your 
-// // InfluxDB data model, and can add more here and in post_influx.cpp if desired
-// #define DEVICE_NAME "aqi_pm25"
-// #define DEVICE_LOCATION "backyard"
-// #define DEVICE_SITE "outdoor"
+// If server runs InfluxDB v2.X, configure here
+// InfluxDB 2 server url, e.g. http://192.168.1.48:8086 (Use: InfluxDB UI -> Load Data -> Client Libraries)
+// #define INFLUXDB_URL "http://influxdbhost.local:8086"
+// InfluxDB 2 server or cloud API authentication token (Use: InfluxDB UI -> Load Data -> Tokens -> <select token>)
+// #define INFLUXDB_TOKEN "--InfluxDB--access-token-value--"
+// InfluxDB 2 organization name or id (Use: InfluxDB UI -> Settings -> Profile -> <name under tile> )
+// #define INFLUXDB_ORG "influxdborg"
+// InfluxDB 2 bucket name (Use: InfluxDB UI -> Load Data -> Buckets)
+// #define INFLUXDB_BUCKET "influxdbbucket"


### PR DESCRIPTION
Used this feature branch to add and test support for a variety of services as a follow-on to the major feature update merged recently into main by @ericklein:

- Updated and tested Dweet support (post_dweet.cpp)
- Updated and tested ThingSpeak support (post_thingspeak.cpp)
- Extended InfluxDB support by adding adding a DEVICE_NAME configuration variable in addition to DEVICE_TYPE to enable more powerful queries and data analysis (post_influx.cpp)
- Tested MQTT support with HomeAssistant
- Extended HomeAssistant support to publishing properly-formatted sensor payloads so they can be integrated with HomeAssistant as entities and displayed/customized in dashboards (hassio_mqtt.cpp)
- Updated secrets_template.h to match current config.h contents
- Updated README.md to reflect recent work and also detail more about how AQI is calculated from PM 2.5
- Added support for simulating the SEN5x sensor to ease development.   Simulated sensor returns random but reasonable values for all SEN5x readings, and is controlled via a #define in config.h

Tested all updates on both ESP8266 (Adafruit Feather Huzzah) and ESP32 (Adafruit ESP32 V2).